### PR TITLE
Introduce &productnameshort; entity

### DIFF
--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -17,6 +17,7 @@
  <info>
   <title>Registering &rhla; &productnumber;</title>
   <productname>&productname;</productname>
+  <productname role="abbrev">&productnameshort;</productname>
   <date><?dbtimestamp format="B d, Y"?></date>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -1,5 +1,6 @@
 <!-- PRODUCT NAME AND VERSIONS -->
 <!ENTITY productname            "SUSE Liberty Linux">
+<!ENTITY productnameshort       "SLL">
 <!ENTITY productnumber          "9">
 
 <!-- PROJECT REPOSITORY URL -->


### PR DESCRIPTION
### Description

Introduce `&productnameshort;` entity as discussed in SLE Writers Call on 2022-11-21.

Tahlia, I wasn't quite sure about the abbreviation. Better check that.
If you are okay with the change, I will take care of cherry-picking it into the different branches.


### Are there any relevant issues/feature requests?

* DOCTEAM-828

### PR creator: Which product versions do the changes apply to?


- SLL
  - [x] next *(current `main`, no backport necessary)*
  - [x] SLL8
  - [x] SLL7
