### PR TITLE
doc-kit updates Sept '23 (SLL7)

### DIFF
--- a/doc-kit.conf
+++ b/doc-kit.conf
@@ -3,10 +3,10 @@ variant: license-gfdl
 
 file: 50fc57833230d2afd445ef11a36e81d2850993b1  .gitignore
 file: c6b4745307e90c9b88905b434cbbaddc54e4541b  .editorconfig
-file: 47e64cba1ddfdfa57fec4da6591e7259ac38afb5  xml/generic-entities.ent
+file: 01205dda71486c3419a0ecd95244524b72b93185  xml/generic-entities.ent
 file: a79a3bc929478668955564bab48aecc8502555f6  xml/network-entities.ent
-file: 877a69c29d30bd89aa36d79dd96c72dbde4a0ed8  xml/common_intro_available_doc.xml
-file: 2024e3be75c45cf26a2b076eee30c697a6e819a1  xml/common_intro_support.xml
+file: 78cb16c93e8a51b4c9ec32c4b30466b87979fb6a  xml/common_intro_available_doc.xml
+file: 6b82b8fa32f3c8cd8c76e804e420ae4a9312ec27  xml/common_intro_support.xml
 file: 578bc097d6cb4ef8aa08dbf4f1bf4400cae124f6  xml/common_intro_convention.xml
 file: fcb8648dbfbe5a036547347e2affbeb353622162  xml/common_intro_feedback.xml
 file: 1c8497ffe563b59832de4b0e106082aa4932a528  xml/common_copyright_gfdl.xml

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -89,7 +89,7 @@
     <title>Related information</title>
     <listitem>
      <para>
-      <link xlink:href="&dsc-sles;-15/html/SLES-all/book-rmt.html">&rmtguide;</link>
+      <link xlink:href="&dsc-sles;-15/html/SLES-all/book-rmt.html"><citetitle>&rmtguide;</citetitle></link>
      </para>
     </listitem>
     <listitem>
@@ -130,9 +130,9 @@
     <para>
      &sles; (&slsa;) 15 is installed and running in the same network as the
      systems you want to register. You can use the &productname; subscription to
-     register &slsa;. To install &slsa; 15, see the
+     register &slsa;. To install &slsa; 15, see
      <link xlink:href="&dsc-sles;-15/html/SLES-all/article-installation.html">
-     &instquick;</link>.
+     <citetitle>&instquick;</citetitle></link>.
     </para>
    </listitem>
    <listitem>

--- a/xml/common_intro_available_doc.xml
+++ b/xml/common_intro_available_doc.xml
@@ -53,14 +53,19 @@
    <term>In your system</term>
    <listitem>
     <para>
-     For offline use, find documentation in your installed system under
-     <filename>/usr/share/doc</filename>. Many commands are also described in
-     detail in their <emphasis>manual pages</emphasis>. To view them, run
-     <command>man</command>, followed by a specific command name. If the
-     <command>man</command> command is not installed on your system, install it
-     with <command>sudo zypper install man</command>.
+      For offline use, the release notes are also available under
+      <filename>/usr/share/doc/release-notes</filename> on your system.
+      The documentation for individual packages is available at
+      <filename>/usr/share/doc/packages</filename>.
     </para>
-   </listitem>
+    <para>
+      Many commands are also described in their <emphasis>manual
+      pages</emphasis>. To view them, run <command>man</command>, followed
+      by a specific command name. If the <command>man</command> command is
+      not installed on your system, install it with <command>sudo zypper
+      install man</command>.
+    </para>
+  </listitem>
   </varlistentry>
  </variablelist>
  </sect1>

--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -36,7 +36,7 @@
   <title>Support statement for &productname;</title>
   <para>
    To receive support, you need an appropriate subscription with &suse;.
-   To view the specific support offerings available to you, go to
+   To view the specific support offers available to you, go to
    <link xlink:href="https://www.suse.com/support/"/> and select your product.
   </para>
   <para>
@@ -59,7 +59,7 @@
     <listitem>
      <para>
       Problem isolation, which means technical support designed to analyze
-      data, reproduce customer problems, isolate problem area and provide a
+      data, reproduce customer problems, isolate a problem area and provide a
       resolution for problems not resolved by Level&nbsp;1 or prepare for
       Level&nbsp;3.
      </para>

--- a/xml/generic-entities.ent
+++ b/xml/generic-entities.ent
@@ -288,7 +288,7 @@ use &deng;! -->
 <!ENTITY klpa                   "KLP">
 <!ENTITY ulp                    "user space live patching">
 <!ENTITY ulpa                   "ULP">
-<!ENTITY kiwi                   "KIWI">
+<!ENTITY kiwi                   "KIWI&#xa0;NG">
 <!ENTITY kprobes                "Kprobes">
 <!ENTITY krb                    "Kerberos">
 <!ENTITY kube                   "Kubernetes">
@@ -428,7 +428,8 @@ use &deng;! -->
 <!-- HARDWARE TECHNOLOGIES -->
 
 <!ENTITY nvme                   "NVMe">
-<!ENTITY nvmeof                 "NVMe over Fabric">
+<!ENTITY nvmeof                 "NVMe-oF">
+<!ENTITY nvmeoff                "NVMe over Fabrics">
 <!ENTITY fcnvme                 "FC-NVMe">
 <!ENTITY dmmpio                 "DM-Multipathing">
 <!ENTITY mpio                   "multipath I/O">
@@ -481,54 +482,54 @@ use &deng;! -->
 <!-- BOOK NAMES -->
 
 <!-- SLES/SLED/Leap -->
-<!ENTITY ayguide                "<citetitle xmlns='http://docbook.org/ns/docbook'>&ay; Guide</citetitle>">
-<!ENTITY deploy                 "<citetitle xmlns='http://docbook.org/ns/docbook'>Deployment Guide</citetitle>">
-<!ENTITY gnomeuser              "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; User Guide</citetitle>">
-<!ENTITY instquick              "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation Quick Start</citetitle>">
-<!ENTITY gnomequick             "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; Quick Start</citetitle>">
-<!ENTITY modulesquick           "<citetitle xmlns='http://docbook.org/ns/docbook'>Modules and Extensions Quick Start</citetitle>">
-<!ENTITY rpiquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>&rpi; Quick Start</citetitle>">
-<!ENTITY admin                  "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
-<!ENTITY reference              "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference</citetitle>">
-<!ENTITY startup                "<citetitle xmlns='http://docbook.org/ns/docbook'>Start-Up</citetitle>">
-<!ENTITY storage_guide          "<citetitle xmlns='http://docbook.org/ns/docbook'>Storage Administration Guide</citetitle>">
-<!ENTITY virtual                "<citetitle xmlns='http://docbook.org/ns/docbook'>Virtualization Guide</citetitle>">
-<!ENTITY auditguide             "<citetitle xmlns='http://docbook.org/ns/docbook'>The Linux Audit Framework</citetitle>">
-<!ENTITY tuning                 "<citetitle xmlns='http://docbook.org/ns/docbook'>System Analysis and Tuning Guide</citetitle>">
-<!ENTITY secguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>Security and Hardening Guide</citetitle>">
-<!ENTITY rmtguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>&rmtool; Guide</citetitle>">
-<!ENTITY sle_rmt_guide_a        "<citetitle xmlns='http://docbook.org/ns/docbook'>&rmt; Guide</citetitle>">
-<!ENTITY upgrade_guide          "<citetitle xmlns='http://docbook.org/ns/docbook'>Upgrade Guide</citetitle>">
-<!ENTITY sle_vgpu_kvm_guide     "<citetitle xmlns='http://docbook.org/ns/docbook'>&nvidia; Virtual GPU for &kvm; Guests</citetitle>">
-<!ENTITY sle_virt_bp_guide      "<citetitle xmlns='http://docbook.org/ns/docbook'>Virtualization Best Practices</citetitle>">
-<!ENTITY sle_amd_sev_guide      "<citetitle xmlns='http://docbook.org/ns/docbook'>AMD Secure Encrypted Virtualization (AMD-SEV) Guide</citetitle>">
-<!ENTITY sle_minvm_guide        "<citetitle xmlns='http://docbook.org/ns/docbook'>&minvm; Quick Start</citetitle>">
-<!ENTITY sle_container_guide    "<citetitle xmlns='http://docbook.org/ns/docbook'>Container Guide</citetitle>">
-<!ENTITY sle_pcidss_guide       "<citetitle xmlns='http://docbook.org/ns/docbook'>&pcidss; (&pcidssa;) Guide</citetitle>">
-<!ENTITY sle_pcidss_guide_a     "<citetitle xmlns='http://docbook.org/ns/docbook'>&pcidssa; Guide</citetitle>">
+<!ENTITY ayguide                "&ay; Guide">
+<!ENTITY deploy                 "Deployment Guide">
+<!ENTITY gnomeuser              "&gnome; User Guide">
+<!ENTITY instquick              "Installation Quick Start">
+<!ENTITY gnomequick             "&gnome; Quick Start">
+<!ENTITY modulesquick           "Modules and Extensions Quick Start">
+<!ENTITY rpiquick               "&rpi; Quick Start">
+<!ENTITY admin                  "Administration Guide">
+<!ENTITY reference              "Reference">
+<!ENTITY startup                "Start-Up">
+<!ENTITY storage_guide          "Storage Administration Guide">
+<!ENTITY virtual                "Virtualization Guide">
+<!ENTITY auditguide             "The Linux Audit Framework">
+<!ENTITY tuning                 "System Analysis and Tuning Guide">
+<!ENTITY secguide               "Security and Hardening Guide">
+<!ENTITY rmtguide               "&rmtool; Guide">
+<!ENTITY sle_rmt_guide_a        "&rmt; Guide">
+<!ENTITY upgrade_guide          "Upgrade Guide">
+<!ENTITY sle_vgpu_kvm_guide     "&nvidia; Virtual GPU for &kvm; Guests">
+<!ENTITY sle_virt_bp_guide      "Virtualization Best Practices">
+<!ENTITY sle_amd_sev_guide      "AMD Secure Encrypted Virtualization (AMD-SEV) Guide">
+<!ENTITY sle_minvm_guide        "&minvm; Quick Start">
+<!ENTITY sle_container_guide    "Container Guide">
+<!ENTITY sle_pcidss_guide       "&pcidss; (&pcidssa;) Guide">
+<!ENTITY sle_pcidss_guide_a     "&pcidssa; Guide">
 
 
 <!-- SLE Micro-specific -->
-<!ENTITY micro_podman_guide     "<citetitle xmlns='http://docbook.org/ns/docbook'>Podman Guide</citetitle>">
+<!ENTITY micro_podman_guide     "Podman Guide">
 <!ENTITY micro_upgrade_guide    "&upgrade_guide;">
 <!ENTITY micro_deploy_guide     "&deploy;">
 
 
 <!-- HA -->
-<!ENTITY haguide                "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
-<!ENTITY haquick                "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation and Setup Quick Start</citetitle>">
-<!ENTITY geoguide               "<citetitle xmlns='http://docbook.org/ns/docbook'>&geo; Clustering Guide</citetitle>">
-<!ENTITY geoquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>&geo; Clustering Quick Start</citetitle>">
-<!ENTITY nfsquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>Highly Available NFS Storage with DRBD and Pacemaker</citetitle>">
-<!ENTITY pcmkremquick           "<citetitle xmlns='http://docbook.org/ns/docbook'>Pacemaker Remote Quick Start</citetitle>">
+<!ENTITY haguide                "Administration Guide">
+<!ENTITY haquick                "Installation and Setup Quick Start">
+<!ENTITY geoguide               "&geo; Clustering Guide">
+<!ENTITY geoquick               "&geo; Clustering Quick Start">
+<!ENTITY nfsquick               "Highly Available NFS Storage with DRBD and Pacemaker">
+<!ENTITY pcmkremquick           "Pacemaker Remote Quick Start">
 
 
 <!-- SUSE Manager -->
-<!ENTITY mgradvtop              "<citetitle xmlns='http://docbook.org/ns/docbook'>Advanced Topics Guide</citetitle>">
-<!ENTITY mgrbestpract           "<citetitle xmlns='http://docbook.org/ns/docbook'>Best Practices Guide</citetitle>">
-<!ENTITY mgrgetstart            "<citetitle xmlns='http://docbook.org/ns/docbook'>Getting Started Guide</citetitle>">
-<!ENTITY mgrrefguide            "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference Guide</citetitle>">
-<!ENTITY mgruserguide           "<citetitle xmlns='http://docbook.org/ns/docbook'>User Guide</citetitle>">
+<!ENTITY mgradvtop              "Advanced Topics Guide">
+<!ENTITY mgrbestpract           "Best Practices Guide">
+<!ENTITY mgrgetstart            "Getting Started Guide">
+<!ENTITY mgrrefguide            "Reference Guide">
+<!ENTITY mgruserguide           "User Guide">
 
 
 
@@ -581,11 +582,11 @@ use &deng;! -->
 <!ENTITY mysql                  "&mariadb;">
 
 <!--SUSE Manager, old guide names -->
-<!ENTITY mgrclientconfguide     "<citetitle xmlns='http://docbook.org/ns/docbook'>Client Configuration Guide</citetitle>">
-<!ENTITY mgrinstguide           "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation &amp; Troubleshooting Guide</citetitle>">
-<!ENTITY mgrproxyquick          "<citetitle xmlns='http://docbook.org/ns/docbook'>Proxy Quick Start</citetitle>">
-<!ENTITY mgrquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>Quick Start</citetitle>">
+<!ENTITY mgrclientconfguide     "Client Configuration Guide">
+<!ENTITY mgrinstguide           "Installation &amp; Troubleshooting Guide">
+<!ENTITY mgrproxyquick          "Proxy Quick Start">
+<!ENTITY mgrquick               "Quick Start">
 
 <!-- SLE, old guide names -->
-<!ENTITY sle_jeos_quick        "<citetitle xmlns='http://docbook.org/ns/docbook'>&jeos; Quick Start</citetitle>">
-<!ENTITY smtguide              "<citetitle xmlns='http://docbook.org/ns/docbook'>Subscription Management Tool Guide</citetitle>">
+<!ENTITY sle_jeos_quick        "&jeos; Quick Start">
+<!ENTITY smtguide              "Subscription Management Tool Guide">


### PR DESCRIPTION
Ran doc-kit to pull in latest updates. Changes to the common files don't impact this article, but I did need to add back some `citetitle` tags since they've been removed from the book title entities. 