### PR TITLE
Add new SLL Lite guide

### DIFF
--- a/DC-lite-quickstart
+++ b/DC-lite-quickstart
@@ -1,5 +1,5 @@
 #
-# DC file for SUSE Liberty Linux
+# DC file for SUSE Liberty Linux Lite
 #
 MAIN="art-lite-quickstart.xml"
 ROOTID="art-lite-quickstart"

--- a/DC-lite-quickstart
+++ b/DC-lite-quickstart
@@ -1,10 +1,10 @@
 #
 # DC file for SUSE Liberty Linux
 #
-MAIN="art-quickstart.xml"
-ROOTID="art-quickstart"
+MAIN="art-lite-quickstart.xml"
+ROOTID="art-lite-quickstart"
 
-PROFAUDIENCE="sll"
+PROFAUDIENCE="sll-l"
 PROFCONDITION="suse-product"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -119,7 +119,7 @@
       </listitem>
     </varlistentry>
     <varlistentry>
-      <term>&reponame; doesn't appear in <command>rmt-cli products list</command>
+      <term>&reponame; does not appear in <command>rmt-cli products list</command>
       after <command>rmt-cli sync</command></term>
       <listitem>
       <para>
@@ -132,7 +132,7 @@
       <term>Mirroring completes with errors</term>
       <listitem>
       <para>
-        If some packages could not be downloaded because of timeouts, rerun the
+        If any packages could not be downloaded because of timeouts, rerun the
         <command>rmt-cli mirror</command> command until all packages are downloaded.
       </para>
       </listitem>
@@ -141,9 +141,9 @@
       <term>Setup script cannot access the &reponame; repository</term>
       <listitem>
       <para>
-        The <filename>repodata</filename> directory on the &rmt; server will not
-        be available until all of the packages for that repository are downloaded.
-        If some packages could not be downloaded to the &rmt; server because of timeouts
+        The <filename>repodata</filename> directory on the &rmt; server is not
+        available until all the packages for that repository are downloaded.
+        If any packages could not be downloaded to the &rmt; server because of timeouts
         during the first mirroring, rerun the <command>rmt-cli mirror</command>
         command until all packages are downloaded.
       </para>

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE article
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<article xml:id="art-lite-quickstart" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <info>
+  <title>Registering CentOS Linux &productnumber; with &rmt;</title>
+  <productname>&productname;</productname>
+  <productname role="abbrev">&productnameshort;</productname>
+  <date><?dbtimestamp format="B d, Y"?></date>
+  <xi:include href="common_copyright_gfdl.xml"/>
+  <abstract>
+   <para>
+    This guide describes how to use &productname; to update CentOS&nbsp;Linux&nbsp;&productnumber;.
+   </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker>
+    <dm:url>https://github.com/SUSE/doc-liberty/issues/new</dm:url>
+    <dm:labels>documentation,issue</dm:labels>
+    <dm:version>7</dm:version>
+    <dm:assignee>tahliar</dm:assignee>
+   </dm:bugtracker>
+   <dm:editurl>https://github.com/SUSE/doc-liberty/edit/maintenance/SLL7/xml/</dm:editurl>
+   <dm:translation>no</dm:translation>
+  </dm:docmanager>
+    <meta name="description" its:translate="yes">How to use &productname; and RMT to update CentOS Linux 7.</meta>
+  <meta name="social-descr" its:translate="yes">Use &productname; to update CentOS 7.</meta>
+  <meta name="task" its:translate="yes">
+    <phrase>Upgrade &amp; Update</phrase>
+    <phrase>Administration</phrase>
+  </meta>
+  <revhistory xml:id="rh-art-lite-quickstart">
+    <revision>
+      <date>2024-06-18</date>
+      <revdescription>
+        <para>
+          Initial release.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
+ </info>
+
+ <section xml:id="introduction-lite-quickstart">
+  <title>Introduction</title>
+   <para>
+    &productname; is a technology and support solution for CentOS Linux &productnumber;.
+    With this one-year subscription, you can register and receive updates for
+    CentOS&nbsp;Linux&nbsp;&productnumber; with &suse;'s &rmtool; (&rmt;). The subscription also
+    includes one entitlement for &sles; 15 to host &rmt;.
+   </para>
+   <para>
+     &rmt; is a proxy system
+    for the &scc;. The &rmt; server is registered with the &scc;, and other systems in the network
+    are registered with the &rmt; server and receive packages from it directly.
+
+   </para>
+   <important role="compact">
+    <para>
+     CentOS&nbsp;Stream is not supported.
+    </para>
+   </important>
+   <itemizedlist>
+    <title>Procedure overview</title>
+    <listitem>
+     <para>
+      If you already have an &rmt; server and only need to <emphasis role="bold">register your
+      CentOS Linux 7 system</emphasis>, skip straight to <xref linkend="register-7-with-rmt"/>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      If you already have an &rmt; server but still need to <emphasis role="bold">mirror the &reponame;
+      &productnumber; repositories</emphasis>, go to <xref linkend="mirror-repositories-with-rmt"/>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      If you still need to <emphasis role="bold">set up the &rmt; server</emphasis>,
+      start with <xref linkend="install-rmt-vm"/> and <xref linkend="configure-rmt-server"/>.
+     </para>
+    </listitem>
+   </itemizedlist>
+ </section>
+
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="install-rmt-vm.xml"/>
+
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="configure-rmt-server.xml"/>
+
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="mirror-repositories-with-rmt.xml"/>
+
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="register-with-rmt.xml"/>
+
+ <section xml:id="troubleshoot-lite-quickstart">
+  <title>Troubleshooting</title>
+  <variablelist>
+    <varlistentry>
+      <term><systemitem>nginx.service</systemitem> is inactive after installing the
+      <package>rmt-server</package> package</term>
+      <listitem>
+      <para>
+        Continue the procedure to configure &rmt; in &yast;. This often resolves
+        the issue. If that fails, Apache might be installed on your server, and
+        must be disabled. Apache conflicts with NGINX because both web servers
+        listen on port 80.
+      </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>&reponame; doesn't appear in <command>rmt-cli products list</command>
+      after <command>rmt-cli sync</command></term>
+      <listitem>
+      <para>
+        Check your network. If the network is down, <command>rmt-cli sync</command> fails without
+        showing an error.
+      </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Mirroring completes with errors</term>
+      <listitem>
+      <para>
+        If some packages could not be downloaded because of timeouts, rerun the
+        <command>rmt-cli mirror</command> command until all packages are downloaded.
+      </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Setup script cannot access the &reponame; repository</term>
+      <listitem>
+      <para>
+        The <filename>repodata</filename> directory on the &rmt; server will not
+        be available until all of the packages for that repository are downloaded.
+        If some packages could not be downloaded to the &rmt; server because of timeouts
+        during the first mirroring, rerun the <command>rmt-cli mirror</command>
+        command until all packages are downloaded.
+      </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Setup script cannot install <package>suseconnect-ng</package> because of
+      package dependencies</term>
+      <listitem>
+      <para>
+        &productname; only supports the latest minor release
+        of <phrase audience="sll">&rhla; or </phrase>CentOS Linux <phrase audience="sll-l">7</phrase>.
+        If your system is running the latest version and <package>suseconnect-ng</package>
+        still has package dependency issues, try the following workaround:
+      </para>
+      <orderedlist>
+        <listitem>
+        <para>
+          Edit the <filename>rmt-client-setup-res</filename> script to add
+          <literal>--skip-broken</literal> to the following line:
+        </para>
+<screen>$YUM install sles_es-release-server suseconnect-ng librepo <emphasis role="bold">--skip-broken</emphasis></screen>
+        </listitem>
+        <listitem>
+        <para>
+          Run the script and accept any proposed package changes.
+          <package>suseconnect-ng</package> will be skipped.
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+          Run the script a second time. The package changes from the first attempt
+          can sometimes resolve the package dependency issues, allowing the second
+          attempt to successfully install <package>suseconnect-ng</package>.
+        </para>
+        </listitem>
+      </orderedlist>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+ </section>
+ <xi:include href="common_legal.xml"/>
+</article>

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -15,14 +15,15 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <info>
-  <title>Registering CentOS Linux &productnumber; with &rmt;</title>
+  <title>Registering CentOS Linux &productnumber; with &productname;</title>
   <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <date><?dbtimestamp format="B d, Y"?></date>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>
-    This guide describes how to use &productname; to update CentOS&nbsp;Linux&nbsp;&productnumber;.
+    This guide describes how to use &productname; and &rmt; to update
+    CentOS&nbsp;Linux&nbsp;&productnumber;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -62,10 +63,9 @@
     includes one entitlement for &sles; 15 to host &rmt;.
    </para>
    <para>
-     &rmt; is a proxy system
-    for the &scc;. The &rmt; server is registered with the &scc;, and other systems in the network
-    are registered with the &rmt; server and receive packages from it directly.
-
+     &rmt; is a proxy system for the &scc;. The &rmt; server is registered with the &scc;,
+     and other systems in the network are registered with the &rmt; server and receive
+     packages from it directly.
    </para>
    <important role="compact">
     <para>

--- a/xml/configure-rmt-server.xml
+++ b/xml/configure-rmt-server.xml
@@ -22,18 +22,28 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
  </info>
 
  <para>
-  Use this procedure to configure the &rmtool; (&rmt;) on &sles; 15.
+  Use this procedure to configure the &rmtool; (&rmt;) on &sles; (&slsa;) 15.
  </para>
  <itemizedlist>
   <title>Requirements</title>
   <listitem>
    <para>
-    &sles; 15 is installed and up to date.
+    <phrase audience="sll">&sles; (&slsa;) 15 is installed and up to date. This machine will be the
+    &rmt; server. You can use the &productname; subscription to register &slsa;. To install &slsa; 15, see
+    <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
+    <citetitle>&instquick;</citetitle></link>.</phrase>
+    <phrase audience="sll-l">A &slsa; 15 virtual machine is installed as described in
+    <xref linkend="install-rmt-vm"/>.</phrase>
    </para>
   </listitem>
   <listitem>
+    <para>
+      The &slsa; machine has a static IP address and host name.
+    </para>
+  </listitem>
+  <listitem>
    <para>
-    You have a &scc; account and organization credentials.
+    You have a <link xlink:href="&sccurl;">&scc;</link> account and organization credentials.
    </para>
   </listitem>
  </itemizedlist>
@@ -44,11 +54,17 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
    <para>
     Install &rmt; on &sles; 15:
    </para>
-<screen>&prompt.root;<command>zypper in rmt-server</command></screen>
+<screen>&prompt.root;<command>zypper install rmt-server</command></screen>
+  </step>
+  <step audience="sll-l">
+    <para>
+      Install the following packages, which are not installed by default on a &minvm;:
+    </para>
+<screen>&prompt.root;<command>zypper install yast2-rmt mariadb nginx</command></screen>
   </step>
   <step>
    <para>
-    Start the <literal>rmt</literal> module in &yast;:
+    Start the &yast; <literal>rmt</literal> module:
    </para>
 <screen>&prompt.root;<command>yast2 rmt</command></screen>
   </step>
@@ -86,7 +102,7 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
   <step>
    <para>
     Enter a <guimenu>Common Name</guimenu> for the SSL certificates. The common
-    name is usually the FQDN of the server.
+    name is usually the host name of the server.
    </para>
   </step>
   <step>
@@ -110,8 +126,8 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
   </step>
   <step>
    <para>
-    &yast; displays the <guimenu>&rmt; Service Status</guimenu>.
-    Select <guimenu>Next</guimenu>.
+    &yast; displays the <guimenu>&rmt; Service Status</guimenu>. If there are no issues,
+    select <guimenu>Next</guimenu>.
    </para>
   </step>
   <step>

--- a/xml/html/rh-art-lite-quickstart.html
+++ b/xml/html/rh-art-lite-quickstart.html
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
+<link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
+<meta name="title" content="Revision History | SLLSLL-L"/>
+<meta name="description" content="Initial release."/>
+<meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
+<meta name="book-title" content="Registering CentOS Linux 7 with RMT"/>
+<meta name="chapter-title" content="Revision History"/>
+<meta name="tracker-url" content="https://github.com/SUSE/doc-liberty/issues/new"/>
+<meta name="tracker-type" content="gh"/>
+<meta name="tracker-gh-assignee" content="tahliar"/>
+<meta name="tracker-gh-labels" content="documentation,issue"/>
+<meta name="tracker-gh-milestone" content="7"/>
+<meta name="publisher" content="SUSE"/><meta property="og:title" content="Revision History | SLLSLL-L"/>
+<meta property="og:description" content="Use SUSE Liberty LinuxSUSE Liberty Linux Lite to update Cent"/>
+<meta property="og:type" content="article"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="Revision History | SLLSLL-L"/>
+<meta name="twitter:description" content="Use SUSE Liberty LinuxSUSE Liberty Linux Lite to update Cent"/>
+<script type="application/ld+json">{
+    "@context": "http://schema.org",
+    "@type": ["TechArticle"],
+    "image": "https://www.suse.com/assets/img/suse-white-logo-green.svg",
+    
+     "isPartOf": {
+      "@type": "CreativeWorkSeries",
+      "name": "Product &amp; Solutions"
+    },
+    
+    "inLanguage": "en",
+    
+
+    "headline": "",
+  
+    "author": [
+      {
+        "@type": "Corporation",
+        "name": "SUSE Product &amp; Solution Documentation Team",
+        "url": "https://www.suse.com/assets/img/suse-white-logo-green.svg"
+      }
+    ],
+      
+    "dateModified": "2024-06-18T00:00+02:00",
+      
+    "datePublished": "2024-06-18T00:00+02:00",
+      
+
+    "about": [
+      
+    ],
+  
+    "sameAs": [
+          "https://www.facebook.com/SUSEWorldwide/about",
+          "https://www.youtube.com/channel/UCHTfqIzPKz4f_dri36lAQGA",
+          "https://twitter.com/SUSE",
+          "https://www.linkedin.com/company/suse"
+    ],
+    "publisher": {
+      "@type": "Corporation",
+      "name": "SUSE",
+      "url": "https://documentation.suse.com",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.suse.com/assets/img/suse-white-logo-green.svg"
+      }
+    }
+  }</script>
+<script type="text/javascript">
+
+if ( window.location.protocol.toLowerCase() != 'file:' ) {
+  document.write('<link rel="stylesheet" type="text/css" href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css"></link>');
+};
+
+</script><noscript><link rel="stylesheet" type="text/css" href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css"/></noscript><script src="static/js/script-purejs.js" type="text/javascript"> </script><script src="static/js/highlight.min.js" type="text/javascript"> </script><script>
+
+$(document).ready(function() {
+  $('.verbatim-wrap.highlight').each(function(i, block) {
+    hljs.highlightBlock(block);
+  });
+});
+hljs.configure({
+  useBR: false
+});
+
+</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-06-18</span></h2>
+        <p>
+          Initial release.
+        </p>
+      </section></div></body></html>

--- a/xml/html/rh-art-lite-quickstart.html
+++ b/xml/html/rh-art-lite-quickstart.html
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
 <meta name="description" content="Initial release."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
-<meta name="book-title" content="Registering CentOS Linux 7 with RMT"/>
+<meta name="book-title" content="Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="chapter-title" content="Revision History"/>
 <meta name="tracker-url" content="https://github.com/SUSE/doc-liberty/issues/new"/>
 <meta name="tracker-type" content="gh"/>
@@ -82,7 +82,7 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-06-18</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</h1><section class="revision"><h2><span class="revision date">2024-06-18</span></h2>
         <p>
           Initial release.
         </p>

--- a/xml/html/rh-art-quickstart.html
+++ b/xml/html/rh-art-quickstart.html
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
+<link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
+<meta name="title" content="Revision History | SLLSLL-L"/>
+<meta name="description" content="RMT script and requirements update."/>
+<meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
+<meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with RMT"/>
+<meta name="chapter-title" content="Revision History"/>
+<meta name="tracker-url" content="https://github.com/SUSE/doc-liberty/issues/new"/>
+<meta name="tracker-type" content="gh"/>
+<meta name="tracker-gh-assignee" content="tahliar"/>
+<meta name="tracker-gh-labels" content="documentation,issue"/>
+<meta name="tracker-gh-milestone" content="7"/>
+<meta name="publisher" content="SUSE"/><meta property="og:title" content="Revision History | SLLSLL-L"/>
+<meta property="og:description" content="Use SUSE Liberty Linux to update RHEL 7 or CentOS 7."/>
+<meta property="og:type" content="article"/>
+<meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="Revision History | SLLSLL-L"/>
+<meta name="twitter:description" content="Use SUSE Liberty Linux to update RHEL 7 or CentOS 7."/>
+<script type="application/ld+json">{
+    "@context": "http://schema.org",
+    "@type": ["TechArticle"],
+    "image": "https://www.suse.com/assets/img/suse-white-logo-green.svg",
+    
+     "isPartOf": {
+      "@type": "CreativeWorkSeries",
+      "name": "Product &amp; Solutions"
+    },
+    
+    "inLanguage": "en",
+    
+
+    "headline": "",
+  
+    "author": [
+      {
+        "@type": "Corporation",
+        "name": "SUSE Product &amp; Solution Documentation Team",
+        "url": "https://www.suse.com/assets/img/suse-white-logo-green.svg"
+      }
+    ],
+      
+    "dateModified": "2024-05-10T00:00+02:00",
+      
+    "datePublished": "2024-03-14T00:00+02:00",
+      
+
+    "about": [
+      
+    ],
+  
+    "sameAs": [
+          "https://www.facebook.com/SUSEWorldwide/about",
+          "https://www.youtube.com/channel/UCHTfqIzPKz4f_dri36lAQGA",
+          "https://twitter.com/SUSE",
+          "https://www.linkedin.com/company/suse"
+    ],
+    "publisher": {
+      "@type": "Corporation",
+      "name": "SUSE",
+      "url": "https://documentation.suse.com",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "https://www.suse.com/assets/img/suse-white-logo-green.svg"
+      }
+    }
+  }</script>
+<script type="text/javascript">
+
+if ( window.location.protocol.toLowerCase() != 'file:' ) {
+  document.write('<link rel="stylesheet" type="text/css" href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css"></link>');
+};
+
+</script><noscript><link rel="stylesheet" type="text/css" href="https://documentation.suse.com/docserv/res/fonts/poppins/poppins.css"/></noscript><script src="static/js/script-purejs.js" type="text/javascript"> </script><script src="static/js/highlight.min.js" type="text/javascript"> </script><script>
+
+$(document).ready(function() {
+  $('.verbatim-wrap.highlight').each(function(i, block) {
+    hljs.highlightBlock(block);
+  });
+});
+hljs.configure({
+  useBR: false
+});
+
+</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-05-10</span></h2>
+        <p>
+          RMT script and requirements update.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-03-27</span></h2>
+        <p>
+          Clarify wording of requirements.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-03-14</span></h2>
+        <p>
+          Initial release.
+        </p>
+      </section></div></body></html>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE section
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<section xml:id="install-rmt-vm" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Installing a virtual machine to host &rmt;</title>
+
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>no</dm:translation>
+  </dm:docmanager>
+ </info>
+
+  <para>
+    Use this procedure to install a &minvm;. This machine will be the &rmtool; (&rmt;) server.
+    You can use your &productname; subscription to register &slsa;.
+  </para>
+  <para>
+    &minvm; is a slimmed-down version of &sles;, available as a preconfigured virtual machine image.
+    If you would prefer to install a full &slsa; machine on bare metal, see
+    <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
+    <citetitle>&instquick;</citetitle></link>.
+  </para>
+  <itemizedlist>
+    <title>Requirements</title>
+    <listitem>
+      <para>
+        You have a &productname; subscription. This subscription entitles you to one
+        &slsa; machine to host &rmt;.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        You have a <link xlink:href="&sccurl;">&scc;</link> account.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        The VM must have a static IP address and host name. This guide includes steps for
+        configuring these, but you must have basic networking knowledge to fill in the details.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        You have the infrastructure to run virtual machines. This procedure explains
+        how to set up the VM to host &rmt;, but does not describe how to use different
+        virtualization products. See the relevant documentation for your infrastructure.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Your virtual machine infrastructure has enough disk space available. The &rmt; server
+        needs enough storage to mirror the &reponame; &productnumber; repositories. Downloaded packages
+        are stored in <filename>/usr/share/rmt/public/repo</filename>, which is a symbolic link to
+        <filename>/var/lib/rmt/public/repo/</filename>. The amount of storage required depends on the
+        number of repositories you mirror. We recommend at least 1.5 times the total size of all enabled
+        repositories.
+      </para>
+      <important>
+        <title>&reponame; &productnumber; repository size</title>
+        <para>
+          The &reponame; repositories will grow substantially over time, because older package
+          versions are not removed. To meet the 1.5x size recommendation, based on the
+          current<footnote><para>As of 20 May, 2024</para></footnote>
+          size of the &reponame; &productnumber; repository, you will need approximately 710&nbsp;GB
+          of disk space available for the &rmt; server.
+        </para>
+      </important>
+    </listitem>
+  </itemizedlist>
+  <procedure xml:id="pro-install-rmt-vm">
+    <title>Installing a virtual machine to host &rmt;</title>
+    <step>
+      <para>
+        Download the <literal>Minimal-VM</literal> image for your VM
+        infrastructure from <link xlink:href="https://www.suse.com/download/sles/"/>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Use the <literal>Minimal-VM</literal> image to start the virtual machine.
+      </para>
+      <para>
+        The default disk size for &minvm; is 24&nbsp;GB. If you can customize the configuration
+        before the installation begins, increase the available storage so that there is enough
+        disk space for repository mirroring.
+      </para>
+    </step>
+    <step>
+      <para>
+        When the &jeosfirstboot; screen appears, select <guimenu>Start</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Choose your keyboard layout and select <guimenu>OK</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Review the <literal>End User License Agreement</literal> and select <guimenu>EXIT</guimenu>.
+        To agree with the terms of the license, select <guimenu>Yes</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Choose your time zone and select <guimenu>OK</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Enter a &rootuser; password and select <guimenu>OK</guimenu>, then confirm the password
+        and select <guimenu>OK</guimenu> again.
+      </para>
+    </step>
+    <step>
+      <para>
+        &jeosfirstboot; shows the command to use to register this VM. Select <guimenu>OK</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        When the VM is ready, log in as the &rootuser; user with the password you entered
+        during setup.
+      </para>
+    </step>
+    <step>
+      <para>
+        Register the VM using your &scc; email address and the registration code for &productname;:
+      </para>
+<screen>&prompt.root;<command>SUSEConnect -e <replaceable>EMAIL_ADDRESS</replaceable> -r <replaceable>REGISTRATION_CODE</replaceable></command></screen>
+      <para>
+        This activates the <literal>Basesystem</literal>, <literal>Server Applications</literal>,
+        and <literal>Python 3</literal> modules.
+      </para>
+    </step>
+    <step>
+      <para>
+        If you did not already increase the VM's disk space before the installation began,
+        increase it now. You might need to shut down the VM to do so. The VM must have enough
+        space to mirror the &reponame; &productnumber; repository.
+      </para>
+    </step>
+  </procedure>
+  <para>
+    You must also configure a static IP address and hostname for the VM. If you are familiar
+    with any networking tools in &slsa;, configure the network with your preferred tool.
+    If not, use the &yast; graphical interface:
+  </para>
+  <procedure xml:id="pro-pro-install-rmt-vm-network">
+    <title>Setting a static IP address in &yast;</title>
+    <step>
+      <para>
+        Install &yast; and the &yast; <literal>network</literal> module:
+      </para>
+<screen>&prompt.root;<command>zypper install yast2 yast2-network</command></screen>
+    </step>
+    <step>
+      <para>
+        Start the &yast; <literal>network</literal> module:
+      </para>
+<screen>&prompt.root;<command>yast2 lan</command></screen>
+    </step>
+    <step>
+      <para>
+        In the <guimenu>Overview</guimenu> tab, select <guimenu>Edit</guimenu> to change the settings
+        of the default <literal>eth0</literal> device. The <guimenu>Network Card Setup</guimenu>
+        dialog opens.
+      </para>
+    </step>
+    <step>
+      <para>
+        In the <guimenu>Address</guimenu> tab, activate <guimenu>Statically Assigned IP Address</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Fill in the <guimenu>IP Address</guimenu>, <guimenu>Subnet Mask</guimenu>, and
+        <guimenu>Hostname</guimenu> fields.
+      </para>
+    </step>
+    <step>
+      <para>
+        Select <guimenu>Next</guimenu>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Switch to the <guimenu>Hostname/DNS</guimenu> tab and fill in the
+        <guimenu>Static Hostname</guimenu> field.
+      </para>
+    </step>
+    <step>
+      <para>
+        Change <guimenu>Set Hostname via DHCP</guimenu> to <literal>no</literal>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Fill in at least one <guimenu>Name Server</guimenu> field.
+      </para>
+    </step>
+    <step>
+      <para>
+        Switch to the <guimenu>Routing</guimenu> tab and select <guimenu>Add</guimenu>. A new
+        dialog opens.
+      </para>
+    </step>
+    <step>
+      <para>
+        Fill in the <guimenu>Gateway</guimenu> field. Make sure to remove the <literal>-</literal>
+        character.
+      </para>
+    </step>
+    <step>
+      <para>
+        From the <guimenu>Device</guimenu> drop-down list, select <literal>eth0</literal>.
+      </para>
+    </step>
+    <step>
+      <para>
+        Select <guimenu>OK</guimenu> to close the dialog.
+      </para>
+    </step>
+    <step>
+      <para>
+        Select <guimenu>OK</guimenu> to complete the configuration and close &yast;.
+      </para>
+    </step>
+    <step>
+      <para>
+        Check the network settings:
+      </para>
+<screen>&prompt.root;<command>ip addr</command></screen>
+      <para>
+        Check the host name:
+      </para>
+<screen>&prompt.root;<command>hostname</command></screen>
+    </step>
+  </procedure>
+  <para>
+    You can now install &rmt; on the virtual machine.
+  </para>
+  <itemizedlist>
+    <title>More information</title>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/smart/virtualization-cloud/html/minimal-vm/">
+        <citetitle>Introduction to &minvm;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/book-virtualization.html">
+        <citetitle>&virtual;</citetitle></link>
+      </para>
+    </listitem>
+  </itemizedlist>
+</section>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -20,11 +20,11 @@
 
   <para>
     Use this procedure to install a &minvm;. This machine will be the &rmtool; (&rmt;) server.
-    You can use your &productname; subscription to register &slsa;.
+    You can use your &productname; subscription to register this machine.
   </para>
   <para>
-    &minvm; is a slimmed-down version of &sles;, available as a preconfigured virtual machine image.
-    If you would prefer to install a full &slsa; machine on bare metal, see
+    &minvm; is a slimmed-down version of &sles; (&slsa;), available as a preconfigured
+    virtual machine image. If you would prefer to install a full &slsa; machine on bare metal, see
     <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
     <citetitle>&instquick;</citetitle></link>.
   </para>
@@ -43,27 +43,26 @@
     </listitem>
     <listitem>
       <para>
-        The VM must have a static IP address and host name. This guide includes steps for
-        configuring these, but you must have basic networking knowledge to fill in the details.
+        The VM must have a static IP address and host name. This guide includes steps for configuring
+        the VM's network setup, but you must have basic networking knowledge to fill in the details.
       </para>
     </listitem>
     <listitem>
       <para>
-        You have the infrastructure to run virtual machines. This procedure explains
+        You have the infrastructure to run virtual machines. This guide explains
         how to set up the VM to host &rmt;, but does not describe how to use different
-        virtualization products. See the relevant documentation for your infrastructure.
+        virtualization products. See the relevant documentation for your product.
       </para>
     </listitem>
     <listitem>
       <para>
-        Your virtual machine infrastructure has enough disk space available. The &rmt; server
-        needs enough storage to mirror the &reponame; &productnumber; repositories. Downloaded packages
-        are stored in <filename>/usr/share/rmt/public/repo</filename>, which is a symbolic link to
-        <filename>/var/lib/rmt/public/repo/</filename>. The amount of storage required depends on the
-        number of repositories you mirror. We recommend at least 1.5 times the total size of all enabled
-        repositories.
+        The &rmt; server needs enough available disk space to mirror the &reponame; &productnumber;
+        repositories. Downloaded packages are stored in <filename>/var/lib/rmt/public/repo/</filename>.
+        The amount of storage required depends on the number of repositories you mirror.
+        We recommend at least 1.5 times the total size of all enabled repositories.
       </para>
       <important>
+<!-- trichardson 2024-06-18: TO DO: New streamlined repos will be available from July 1 -->
         <title>&reponame; &productnumber; repository size</title>
         <para>
           The &reponame; repositories will grow substantially over time, because older package
@@ -79,7 +78,7 @@
     <title>Installing a virtual machine to host &rmt;</title>
     <step>
       <para>
-        Download the <literal>Minimal-VM</literal> image for your VM
+        Download the appropriate <literal>Minimal-VM</literal> image for your virtualization
         infrastructure from <link xlink:href="https://www.suse.com/download/sles/"/>.
       </para>
     </step>
@@ -171,8 +170,7 @@
     <step>
       <para>
         In the <guimenu>Overview</guimenu> tab, select <guimenu>Edit</guimenu> to change the settings
-        of the default <literal>eth0</literal> device. The <guimenu>Network Card Setup</guimenu>
-        dialog opens.
+        of the <literal>eth0</literal> device. The <guimenu>Network Card Setup</guimenu> dialog opens.
       </para>
     </step>
     <step>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -149,7 +149,7 @@
     </step>
   </procedure>
   <para>
-    You must also configure a static IP address and hostname for the VM. If you are familiar
+    You must also configure a static IP address and host name for the VM. If you are familiar
     with any networking tools in &slsa;, configure the network with your preferred tool.
     If not, use the &yast; graphical interface:
   </para>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -121,7 +121,8 @@
     </step>
     <step>
       <para>
-        &jeosfirstboot; shows the command to use to register this VM. Select <guimenu>OK</guimenu>.
+        &jeosfirstboot; shows the command to use to register this VM. You do not need to write this
+        down; the command is explained in this procedure. Select <guimenu>OK</guimenu>.
       </para>
     </step>
     <step>
@@ -238,9 +239,12 @@
       </para>
 <screen>&prompt.root;<command>ip addr</command></screen>
       <para>
-        Check the host name:
+        Check that the network interface can access external networks:
       </para>
-<screen>&prompt.root;<command>hostname</command></screen>
+<screen>&prompt.root;<command>ping www.example.com</command></screen>
+      <para>
+        Cancel the ping with <keycombo><keycap function="control"/><keycap>C</keycap></keycombo>.
+      </para>
     </step>
   </procedure>
   <para>
@@ -251,13 +255,13 @@
     <listitem>
       <para>
         <link xlink:href="https://documentation.suse.com/smart/virtualization-cloud/html/minimal-vm/">
-        <citetitle>Introduction to &minvm;</citetitle></link>
+        Introduction to &minvm;</link>
       </para>
     </listitem>
     <listitem>
       <para>
         <link xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/book-virtualization.html">
-        <citetitle>&virtual;</citetitle></link>
+        &virtual;</link>
       </para>
     </listitem>
   </itemizedlist>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -9,7 +9,7 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Mirroring &productname; repositories with &rmt;</title>
+ <title>Mirroring &reponame; repositories with &rmt;</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -18,19 +18,22 @@
  </info>
 
  <para>
-  Use this procedure to mirror the &productname; repositories for &rhel; &productnumber;
-  and CentOS Linux &productnumber;.
+  Use this procedure to mirror the &reponame; repositories for
+  <phrase audience="sll">&rhel; &productnumber; and </phrase>CentOS Linux &productnumber;.
  </para>
  <itemizedlist>
   <title>Requirements</title>
   <listitem>
    <para>
-    <xref linkend="configure-rmt-server"/>
+    The &rmt; server is installed and up to date.
    </para>
   </listitem>
   <listitem>
    <para>
-    The &rmt; server has enough storage available for repository mirroring.
+    The &rmt; server has enough storage available for repository mirroring. The amount of storage
+    required depends on the number of repositories you mirror. We recommend at least 1.5 times
+    the total size of all enabled repositories. Be aware that the &reponame; repositories will
+    grow substantially over time.
    </para>
   </listitem>
   <listitem>
@@ -46,7 +49,7 @@
  </itemizedlist>
 
  <procedure xml:id="pro-mirror-repositories-with-rmt">
-  <title>Mirroring &productname; repositories with &rmt;</title>
+  <title>Mirroring the &reponame; repositories with &rmt;</title>
   <step>
    <para>
     On the &rmt; server, update the available product and repository metadata:
@@ -61,14 +64,14 @@
   </step>
   <step>
    <para>
-    Enable &productname; using the product ID <literal>1251</literal>:
+    Enable &reponame; &productnumber; using the product ID <literal>1251</literal>:
    </para>
 <screen>&prompt.root;<command>rmt-cli product enable 1251</command></screen>
    <para>
     This enables all of the default repositories associated with the product.
    </para>
   </step>
-  <step>
+  <step audience="sll">
    <para>
     If your subscription includes the &ha; extension, enable the extension using
     the product ID <literal>1252</literal>:
@@ -83,8 +86,8 @@
   </step>
   <step>
    <para>
-    If you also need the <literal>Source</literal> or <literal>Debug</literal>
-    repositories, find and enable them with the following commands:
+    If you also need the <literal>Source</literal> repository, find and enable it with the
+    following commands:
    </para>
 <screen>&prompt.root;<command>rmt-cli repo list --all | grep RES-</command>
 &prompt.root;<command>rmt-cli repo enable <replaceable>REPO_ID</replaceable></command></screen>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -68,7 +68,7 @@
    </para>
 <screen>&prompt.root;<command>rmt-cli product enable 1251</command></screen>
    <para>
-    This enables all of the default repositories associated with the product.
+    This enables all the default repositories associated with the product.
    </para>
   </step>
   <step audience="sll">

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -1,7 +1,9 @@
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname            "SUSE Liberty Linux">
+<!ENTITY productname            "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase audience='sll'>SUSE Liberty Linux</phrase><phrase audience='sll-l'>SUSE Liberty Linux Lite</phrase></phrase>">
+<!ENTITY productnameshort       "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase audience='sll'>SLL</phrase><phrase audience='sll-l'>SLL-L</phrase></phrase>">
 <!ENTITY productnumber          "7">
-<!ENTITY productnameshort       "SLL">
+
+<!ENTITY reponame               "SUSE Liberty Linux">
 
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url               "https://github.com/SUSE/doc-liberty">

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -9,7 +9,7 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Registering &rhla; or CentOS Linux with &rmt;</title>
+ <title>Registering <phrase audience="sll">&rhla; or </phrase>CentOS Linux with &rmt;</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -19,8 +19,8 @@
  </info>
 
  <para>
-  Use this procedure to register &rhel; &productnumber; or CentOS Linux &productnumber;
-  with the &rmt; server.
+  Use this procedure to register <phrase audience="sll">&rhel; &productnumber; or </phrase>
+  CentOS Linux &productnumber; with the &rmt; server.
  </para>
  <important role="compact">
   <para>
@@ -31,12 +31,7 @@
   <title>Requirements</title>
   <listitem>
    <para>
-    <xref linkend="configure-rmt-server"/>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    <xref linkend="mirror-repositories-with-rmt"/>
+    The system you want to register can access the &rmt; server.
    </para>
   </listitem>
   <listitem>
@@ -46,13 +41,14 @@
   </listitem>
   <listitem>
    <para>
-    The system you want to register can access the &rmt; server.
+    The &reponame; &productnumber; repositories are available on the &rmt; server.
    </para>
   </listitem>
   <listitem>
    <para>
-    The system you want to register is running the latest minor release of &rhla; &productnumber;
-    or CentOS Linux &productnumber;.
+    The system you want to register is up to date. &productname; only supports the latest minor
+    release of <phrase audience="sll">&rhla;&nbsp;&productnumber; or</phrase>
+    CentOS&nbsp;Linux&nbsp;&productnumber;.
    </para>
   </listitem>
   <listitem>
@@ -64,10 +60,10 @@
   </listitem>
   <listitem>
    <para>
-    You have a &productname; subscription activated in the &scc;.
+    You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
    </para>
   </listitem>
-  <listitem>
+  <listitem audience="sll">
    <para>
     You have removed the system from any &rh; subscription services it was
     registered to.
@@ -75,7 +71,7 @@
   </listitem>
  </itemizedlist>
  <procedure xml:id="pro-register-rhel-with-rmt">
-  <title>Registering &rhla; or CentOS Linux with &rmt;</title>
+  <title>Registering <phrase audience="sll">&rhla; or </phrase>CentOS Linux with &rmt;</title>
   <step>
    <para>
     Download the <filename>rmt-client-setup-res</filename> script:
@@ -158,7 +154,7 @@ Installed Products:
     You should see <literal>RES-&productnumber;-Updates</literal>.
    </para>
   </step>
-  <step>
+  <step audience="sll">
    <para>
     If your subscription includes the &ha; extension, activate it with the
     following command:


### PR DESCRIPTION
### PR creator: Description

Added new guide for SLL Lite. 
PDF: [art-lite-quickstart_en.pdf](https://github.com/user-attachments/files/15879828/art-lite-quickstart_en.pdf)

Open issue:
- From July 1 the SLL 7 repos will be restuctured, so the main repo won't be so enormous. But the size will still be constantly changing, so how do I stay on top of that? I would love it if we can add a function to SCC to view a repo's size.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done

---

Add an additional entry for the Docserv config in https://gitlab.suse.de/susedoc/docserv-config/-/merge_requests/914