### PR TITLE
Add VM procedure for RMT (SLL7)

### DIFF
--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -135,7 +135,7 @@
     <listitem>
      <para>
       If you still need to <emphasis role="bold">set up the &rmt; server</emphasis>, start with
-      <xref linkend="configure-rmt-server"/>.
+      <xref linkend="install-rmt-vm"/> and <xref linkend="configure-rmt-server"/>.
      </para>
     </listitem>
 
@@ -186,51 +186,7 @@
    </itemizedlist>
  </section>
 
- <section xml:id="requirements-quickstart">
-  <title>Requirements</title>
-  <itemizedlist>
-   <listitem>
-    <para>
-     You have a &productname; subscription.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     You have a <link xlink:href="&sccurl;">&scc;</link> account.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The systems you want to register are up to date. &productname; only
-     supports the latest minor release of each &rhla; or CentOS Linux version.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     &sles; (&slsa;) 15 is installed and up to date. This machine will be
-     the &rmt; server. You can use the &productname; subscription to
-     register &slsa;. To install &slsa; 15, see
-     <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
-     <citetitle>&instquick;</citetitle></link>.
-    </para>
-   </listitem>
-   <listitem>
-     <para>
-      The systems you want to register can reach the &rmt; server.
-     </para>
-   </listitem>
-   <listitem>
-    <para>
-     The &rmt; server has enough storage available for repository mirroring.
-     Downloaded packages are stored in <filename>/usr/share/rmt/public/repo</filename>,
-     which is a symbolic link to <filename>/var/lib/rmt/public/repo/</filename>.
-     The amount of storage required depends on the number of repositories you mirror.
-     We recommend at least 1.5 times the total size of all enabled repositories.
-     Be aware that these repositories will grow substantially over time.
-    </para>
-   </listitem>
-  </itemizedlist>
- </section>
+<xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="install-rmt-vm.xml"/>
 
 <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="configure-rmt-server.xml"/>
 

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2024-06-27</date>
+      <revdescription>
+        <para>
+          Add Minimal VM procedure.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-05-10</date>
       <revdescription>
         <para>
@@ -89,12 +97,12 @@
    <itemizedlist>
      <listitem>
        <para>
-         &smtool; (&smt;) on &sle; 12
+         &smtool; (&smt;)
        </para>
      </listitem>
      <listitem>
        <para>
-         &rmtool; (&rmt;) on &sle; 15
+         &rmtool; (&rmt;)
        </para>
      </listitem>
      <listitem>
@@ -104,39 +112,36 @@
      </listitem>
    </itemizedlist>
    <para>
-    This guide describes how to register with &rmt; on &sle; 15. &rmt; is a proxy system for the
+    This guide describes how to register with an &rmt; server. &rmt; is a proxy system for the
     &scc;. The &rmt; server is registered with the &scc;, and other systems in the network are
     registered with the &rmt; server and receive packages from it directly.
    </para>
-   <orderedlist>
+   <itemizedlist>
     <title>Procedure overview</title>
     <listitem>
      <para>
-      <xref linkend="requirements-quickstart"/>. Make sure you have everything
-      required for the following procedures.
+      If you already have an &rmt; server and only need to <emphasis role="bold">register your
+      &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber; system</emphasis>,
+      skip straight to <xref linkend="register-7-with-rmt"/>.
      </para>
     </listitem>
     <listitem>
      <para>
-      <xref linkend="configure-rmt-server"/>. This server must be installed on
-      &sles; 15. You can skip this step if you already have an &rmt; server in
-      your network.
+      If you already have an &rmt; server but still need to <emphasis role="bold">mirror the
+      &productname;&nbsp;&productnumber; repositories</emphasis>, go to
+      <xref linkend="mirror-repositories-with-rmt"/>.
      </para>
     </listitem>
     <listitem>
      <para>
-      <xref linkend="mirror-repositories-with-rmt"/>. You can skip this step if
-      &productname; is already enabled and mirrored on your &rmt; server.
+      If you still need to <emphasis role="bold">set up the &rmt; server</emphasis>, start with
+      <xref linkend="configure-rmt-server"/>.
      </para>
     </listitem>
-    <listitem>
-     <para>
-      <xref linkend="register-7-with-rmt"/>. &rmt; includes a setup script to
-      automate the registration process.
-     </para>
-    </listitem>
-   </orderedlist>
-   <!-- Can delete this if/when all names have been changed-->
+
+   </itemizedlist>
+   <!-- Can delete this if/when all names have been changed
+        trichardson 2024-06-26: Repo names have changed but repo labels still include RES -->
    <note>
     <title><emphasis>&productname;</emphasis> and <emphasis>&sles; with Expanded Support</emphasis></title>
     <para>

--- a/xml/configure-rmt-server.xml
+++ b/xml/configure-rmt-server.xml
@@ -47,7 +47,7 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
   <title>Configuring the &rmt; server</title>
   <step>
    <para>
-    Install &rmt; on &sles; 15:
+    On the &slsa; machine, install &rmt;:
    </para>
 <screen>&prompt.root;<command>zypper install rmt-server</command></screen>
   </step>
@@ -86,12 +86,8 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
   </step>
   <step>
    <para>
-    If a password for the &mariadb; root user is already set, enter the password
-    when prompted, then select <guimenu>OK</guimenu>.
-   </para>
-   <para>
-     If no password is set for the &mariadb; root user, enter and confirm a new
-     password when prompted, then select <guimenu>OK</guimenu>.
+    When prompted, enter and confirm a new password for the &mariadb; root user, then select
+    <guimenu>OK</guimenu>.
    </para>
   </step>
   <step>

--- a/xml/configure-rmt-server.xml
+++ b/xml/configure-rmt-server.xml
@@ -28,12 +28,7 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
   <title>Requirements</title>
   <listitem>
    <para>
-    <phrase audience="sll">&sles; (&slsa;) 15 is installed and up to date. This machine will be the
-    &rmt; server. You can use the &productname; subscription to register &slsa;. To install &slsa; 15, see
-    <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
-    <citetitle>&instquick;</citetitle></link>.</phrase>
-    <phrase audience="sll-l">A &slsa; 15 virtual machine is installed as described in
-    <xref linkend="install-rmt-vm"/>.</phrase>
+    A &slsa; 15 virtual machine is installed as described in <xref linkend="install-rmt-vm"/>.
    </para>
   </listitem>
   <listitem>
@@ -56,7 +51,7 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
    </para>
 <screen>&prompt.root;<command>zypper install rmt-server</command></screen>
   </step>
-  <step audience="sll-l">
+  <step>
     <para>
       Install the following packages, which are not installed by default on a &minvm;:
     </para>

--- a/xml/html/rh-art-quickstart.html
+++ b/xml/html/rh-art-quickstart.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
-<meta name="description" content="RMT script and requirements update."/>
+<meta name="description" content="Add Minimal VM procedure."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with RMT"/>
 <meta name="chapter-title" content="Revision History"/>
@@ -40,7 +40,7 @@
       }
     ],
       
-    "dateModified": "2024-05-10T00:00+02:00",
+    "dateModified": "2024-06-27T00:00+02:00",
       
     "datePublished": "2024-03-14T00:00+02:00",
       
@@ -82,7 +82,11 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-05-10</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-06-27</span></h2>
+        <p>
+          Add Minimal VM procedure.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-05-10</span></h2>
         <p>
           RMT script and requirements update.
         </p>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -34,7 +34,6 @@
     <listitem>
       <para>
         You have a &productname; subscription.
-        <phrase audience="sll">You can register &slsa; with this subscription.</phrase>
         <phrase audience="sll-l">This subscription entitles you to one &slsa; machine to host &rmt;.</phrase>
       </para>
     </listitem>
@@ -90,13 +89,13 @@
       </para>
       <para>
         The default disk size for &minvm; is 24&nbsp;GB. If you can customize the configuration
-        before the installation begins, increase the available storage so that there is enough
+        before the installation begins, increase the available storage so there is enough
         disk space for repository mirroring.
       </para>
     </step>
     <step>
       <para>
-        When the &jeosfirstboot; screen appears, select <guimenu>Start</guimenu>.
+        When the <literal>&jeosfirstboot;</literal> screen appears, select <guimenu>Start</guimenu>.
       </para>
     </step>
     <step>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -19,21 +19,23 @@
  </info>
 
   <para>
-    Use this procedure to install a &minvm;. This machine will be the &rmtool; (&rmt;) server.
+    Use this procedure to install a &minvm;, a preconfigured virtual machine image that contains a slimmed-down version of &sles; (&slsa;). This machine will be the &rmtool; (&rmt;) server.
     You can use your &productname; subscription to register this machine.
   </para>
-  <para>
-    &minvm; is a slimmed-down version of &sles; (&slsa;), available as a preconfigured
-    virtual machine image. If you would prefer to install a full &slsa; machine on bare metal, see
-    <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
-    <citetitle>&instquick;</citetitle></link>.
-  </para>
+  <tip role="compact">
+    <para>
+      If you would prefer to install a full &slsa; machine on bare metal, see
+      <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-installation.html">
+      <citetitle>&instquick;</citetitle></link>.
+    </para>
+  </tip>
   <itemizedlist>
     <title>Requirements</title>
     <listitem>
       <para>
-        You have a &productname; subscription. This subscription entitles you to one
-        &slsa; machine to host &rmt;.
+        You have a &productname; subscription.
+        <phrase audience="sll">You can register &slsa; with this subscription.</phrase>
+        <phrase audience="sll-l">This subscription entitles you to one &slsa; machine to host &rmt;.</phrase>
       </para>
     </listitem>
     <listitem>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -43,7 +43,7 @@
   </listitem>
   <listitem>
    <para>
-    You have a &productname; subscription activated in the &scc;.
+    You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -31,17 +31,17 @@
   <title>Requirements</title>
   <listitem>
    <para>
-    The system you want to register can access the &rmt; server.
-   </para>
-  </listitem>
-  <listitem>
-   <para>
     The &rmt; server is running <package>rmt-server</package> version 2.15 or later.
    </para>
   </listitem>
   <listitem>
    <para>
     The &reponame; &productnumber; repositories are available on the &rmt; server.
+   </para>
+  </listitem>
+    <listitem>
+   <para>
+    The system you want to register can access the &rmt; server.
    </para>
   </listitem>
   <listitem>
@@ -175,6 +175,6 @@ Installed Products:
   </step>
  </procedure>
  <para>
-  You can now update your system from repositories provided by &productname;.
+  You can now keep your system up to date from repositories provided by &productname;.
  </para>
 </section>


### PR DESCRIPTION
### PR creator: Description

After writing the VM procedure for SLL Lite, I'm now rolling it out to the other Liberty guides. 
I'm *not* including it for the SMT guide, because SLL7 is moving to LTSS soon, and SMT will no longer be supported.


### PR creator: Are there any relevant issues/feature requests?

* GitHub Issue #...
* Jira Issue #...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
