### PR TITLE
Updates for SLL7 LTSS

### DIFF
--- a/DC-quickstart-smt
+++ b/DC-quickstart-smt
@@ -4,6 +4,7 @@
 MAIN="art-quickstart-smt.xml"
 ROOTID="art-quickstart-smt"
 
+PROFAUDIENCE="sll"
 PROFCONDITION="suse-product"
 #PROFCONDITION="suse-product;beta"
 #PROFCONDITION="community-project"

--- a/xml/app-temp-script.xml
+++ b/xml/app-temp-script.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE section
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<appendix xml:id="app-temp-script" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>&rmt; registration script for &productname;</title>
+
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>no</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <para>
+  Sometimes a new registration script is available for &productname;, but is not yet available from
+  the &rmt; server because of different release cycles. In this case, the new registration script
+  is shown here. Save this script as <filename>rmt-client-setup-res</filename>.
+ </para>
+
+<screen>#!/bin/sh
+
+SUSECONNECT=/usr/bin/SUSEConnect
+RPM=/usr/bin/rpm
+DNF=/usr/bin/dnf
+CURL=/usr/bin/curl
+YUM=/usr/bin/yum
+YUM_CONFIG_MGR=/usr/bin/yum-config-manager
+
+TEMPFILE="/etc/pki/ca-trust/source/anchors/rmt.crt"
+UPDATE_CA_TRUST=/usr/bin/update-ca-trust
+RPM_GPG_KEY_LOCATION="/etc/pki/rpm-gpg"
+
+PARAMS=$@
+YES_PARAM=""
+
+import_rpm_signing_keys() {
+    $RPM --import ${RPM_GPG_KEY_LOCATION}/*
+}
+
+usage() {
+    cat &lt;&lt; EOT &gt;&amp;2
+
+   $1
+
+   $0 script installs SUSEConnect and its dependencies and calls rmt-client-setup script that registers to rmt
+
+  Usage: $0 &lt;registration URL&gt; [--regcert &lt;url&gt;] [--regdata &lt;filename&gt;] [--de-register] [--yes]
+  Usage: $0 --host &lt;hostname of the RMT server&gt; [--regcert &lt;url&gt;] [--regdata &lt;filename&gt;] [--de-register] [--yes]
+  Usage: $0 --host &lt;hostname of the RMT server&gt; [--fingerprint &lt;fingerprint of server cert&gt;] [--regdata &lt;filename&gt;] [--de-register] [--yes]
+         configures a SLE client to register against a different registration server
+
+  Example: $0 https://rmt.example.com/
+  Example: $0 --host rmt.example.com --regcert http://rmt.example.com/certs/rmt.crt --yes
+
+EOT
+
+    exit 1
+}
+
+# We need only REGURL and RMTNAME, all other parameters are just passed to rmt-client-setup script
+REGURL=""
+RMTNAME=""
+
+while true; do
+    case "$1" in
+        --fingerprint | --regcert | --regdata)
+             test -z "$2" &amp;&amp; usage "Option $1 needs an argument"
+             shift
+             ;;
+        --host)
+             test -z "$2" &amp;&amp; usage "Option $1 needs an argument"
+             RMTNAME="$2"
+             REGURL="http://${RMTNAME}"
+             shift
+             ;;
+        --de-register)
+             DE_REGISTER="Y"
+             ;;
+        --yes)
+             YES_PARAM="--yes"
+             ;;
+        "")
+             break
+             ;;
+        -h|--help)
+             usage
+             ;;
+        https://*)
+             RMTNAME="${1:8}"
+             REGURL="$1"
+             ;;
+        http://*)
+             REGURL="$1"
+             RMTNAME="${REGURL:7}"
+             ;;
+        *)
+             usage "Unknown option $1"
+             ;;
+    esac
+    shift
+done
+
+if [ "$(id -u)" != "0" ]; then
+    echo "You must be root. Abort."
+    exit 1
+fi
+
+if [ -z "$REGURL" ]; then
+    echo "Missing registration URL. Abort."
+    exit 1
+fi
+
+if [ ! -x $RPM ]; then
+    echo "rpm command not found. Abort."
+    exit 1
+fi
+
+if [ ! -x $CURL ]; then
+    echo "curl command not found. Abort."
+    exit 1
+fi
+
+if [ ! -e /etc/os-release ]; then
+    echo "/etc/os-release file not found. Couldn't determine OS. Abort."
+    exit 1
+fi
+
+# Import Self-signed CERT as Trusted
+if [ -z "$REGCERT" ]; then
+    CERTURL=$(echo "$REGURL" | awk -F/ '{print "https://" $3 "/rmt.crt"}')
+else
+    CERTURL="$REGCERT"
+fi
+
+$CURL --tlsv1.2 --silent --insecure --connect-timeout 10 --output $TEMPFILE $CERTURL
+if [ $? -ne 0 ]; then
+    echo "Download failed. Abort."
+    exit 1
+fi
+
+if [ -x $UPDATE_CA_TRUST ]; then
+    $UPDATE_CA_TRUST enable
+    $UPDATE_CA_TRUST extract
+fi
+
+SLL_version=$(grep "VERSION_ID" /etc/os-release | cut -d\" -f2 | cut -d\. -f1)
+SLL_name=$(grep "^ID=" /etc/os-release | cut -d\" -f2 | cut -d\. -f1)
+if [[ ${SLL_version} -gt 8 ]]; then
+   SLL_name="SLL"
+   SLL_release_package="sll-release"
+elif [[ ${SLL_version} -eq 7 ]]; then
+   # if RES7 is present we always assume customer has bought LTSS, if he does not, script fails
+   # so no LTSS customers have to edit the script manually
+   if [ "${SLL_name}" = "ol" ]; then
+      SLL_name="RES-OL-LTSS"
+      SLL_version="7"
+      SLL_release_package="sles_es-release-server-ol"
+   else
+      SLL_name="RES-LTSS"
+      SLL_version="7"
+      SLL_release_package="sles_es-release-server"
+   fi
+   # stop when HA, because HA is not supported within LTSS for SLL7
+   if [ -f /etc/product.d/RES-HA.prod ]; then
+        usage "HA product is not supported in RES7 LTSS, please remove the product"
+   fi
+elif [[ ${SLL_version} -eq 8 ]]; then
+    SLL_name="RES"
+    SLL_release_package="sles_es-release"
+else
+   echo "Unsupported or unknown base version. Abort"
+   exit 1
+fi
+
+echo "Detected ${SLL_name} version: ${SLL_version}"
+
+echo "Importing repomd.xml.key"
+if [[ ${SLL_version} -eq 7 ]]; then
+  $CURL --silent --show-error --insecure ${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+else
+  $CURL --silent --show-error --insecure ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+fi
+$RPM --import repomd.xml.key
+
+if [ ! -x $SUSECONNECT ]; then
+    echo "Downloading SUSEConnect"
+if [[ ${SLL_version} -gt 7 ]]; then
+
+    if [ ! -x $DNF ]; then
+        echo "dnf command not found. Abort."
+        exit 1
+    fi
+
+    echo "Disabling all repositories"
+    $DNF config-manager --disable $(dnf repolist -q | awk '{ print $1 }' | grep -v repo)
+    # sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/*
+    # on RHEL9 (not RHEL8) redhat-release is protected and cannot be updated to sll-release
+    if [ -f /etc/dnf/protected.d/redhat-release.conf ]; then
+       rm -f /etc/dnf/protected.d/redhat-release.conf
+    fi
+
+    $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update
+    $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update
+    $DNF install -y --allowerasing ${SLL_release_package}
+
+    # For RHEL8/CentOS8, remove all old signing keys and import SUSE keys installed with sles_es-release package
+    if [[ ${SLL_version} -eq 8 ]]; then
+        import_rpm_signing_keys
+    fi
+
+    $DNF install SUSEConnect librepo
+    $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}_${SLL_version}_x86_64_update"
+    $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
+
+elif [[ ${SLL_version} -eq 7 ]]; then
+    # For SLL7 we need to have yum, yum_config_mgr, sles_os-release-server, etc..
+    if [ ! -x "$YUM_CONFIG_MGR" ]; then
+        echo "YUM config manager is not installed. Please install yum-config-manager and retry. Abort."
+        exit 1
+    fi
+
+    echo "Disabling all repositories"
+    $YUM_CONFIG_MGR --disable \* &gt; /dev/null
+
+    # on Centos /usr/share/redhat-release is a file, on RHEL and RES it is a directory
+    # so this is CentOS only workaround (on some system it is a normal file, on some systems a symlink)
+    if [ -f /usr/share/redhat-release ] || [ -h /usr/share/redhat-release ]; then
+       rm -f /usr/share/redhat-release
+    fi
+
+    $YUM_CONFIG_MGR --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update
+    if [ ${SLL_name} = "RES-OL-LTSS" ]; then
+    	$YUM_CONFIG_MGR --add-repo ${REGURL}/repo/SUSE/Updates/RES-BASE/${SLL_version}/x86_64/update
+    fi
+    $YUM_CONFIG_MGR --enable *suse.* &gt; /dev/null
+
+    $YUM install -y ${SLL_release_package} suseconnect-ng librepo
+    $YUM update -y yum
+    $YUM_CONFIG_MGR --disable \* &gt; /dev/null
+fi
+elif [[ ${SLL_version} -eq 8 ]]; then
+    # For SLL8, the release package is already installed, just import the keys
+    import_rpm_signing_keys
+fi
+
+$CURL --silent --show-error --insecure $REGURL/tools/rmt-client-setup --output rmt-client-setup
+echo "Running rmt-client-setup $PARAMS"
+if [ -n "$YES_PARAM" ]; then
+    PARAMS=$(echo $PARAMS | sed 's/--yes//')
+    yes | sh rmt-client-setup $PARAMS
+else
+    sh rmt-client-setup $PARAMS
+fi
+
+if [[ ${SLL_version} -gt 8 ]]; then
+    systemctl start suseconnect-keepalive.timer
+    systemctl enable suseconnect-keepalive.timer
+fi
+</screen>
+
+</appendix>

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-lite-quickstart">
     <revision>
+      <date>2024-07-01</date>
+      <revdescription>
+        <para>
+          Updates for LTSS.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-06-18</date>
       <revdescription>
         <para>
@@ -138,7 +146,7 @@
       </listitem>
     </varlistentry>
     <varlistentry>
-      <term>Setup script cannot access the &reponame; repository</term>
+      <term>Setup script cannot access the &reponame; repositories</term>
       <listitem>
       <para>
         The <filename>repodata</filename> directory on the &rmt; server is not

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -193,5 +193,6 @@
     </varlistentry>
   </variablelist>
  </section>
+ <xi:include href="app-temp-script.xml"/>
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/art-quickstart-smt.xml
+++ b/xml/art-quickstart-smt.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2024-07-01</date>
+      <revdescription>
+        <para>
+          Retire guide for LTSS.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-03-27</date>
       <revdescription>
         <para>
@@ -62,7 +70,90 @@
   </revhistory>
  </info>
 
- <section xml:id="introduction-quickstart-smt">
+ <section xml:id="liberty-7-ltss">
+   <title>End of general support for &productname; &productnumber;</title>
+   <warning>
+     <title>&smt; is not supported with &productname; LTSS &productnumber;</title>
+     <para>
+      &productname; &productnumber; has reached the end of general support and is now in LTSS
+      (Long Term Service Support).
+     </para>
+     <para>
+       Registering systems with &smt; is not supported under &productname; LTSS &productnumber;.
+       You can register &rhla; &productnumber; or CentOS Linux &productnumber; with either
+       &suma; or the &rmtool; (&rmt;).
+     </para>
+     <para>
+       Before you register existing systems with &rmt;, de-register them from &smt;.
+       You can do this directly from the &smt; server using the steps in
+       <xref linkend="pro-deregister-client-from-smt"/>.
+     </para>
+     <para>
+      To migrate from &smt; to &rmt;, see
+      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-rmt-migrate.html">
+      Migrate from SMT to RMT</link> in <citetitle>&rmtguide;</citetitle>.
+      Alternatively, install a fresh &rmt; server using the steps in
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with RMT</citetitle></link>.
+     </para>
+   </warning>
+
+   <procedure xml:id="pro-deregister-client-from-smt">
+     <title>De-registering a client from &smt;</title>
+     <step>
+       <para>
+         List the existing clients and make a note of the client IDs:
+       </para>
+<screen>&prompt.root;<command>smt-list-registrations</command></screen>
+     </step>
+     <step>
+       <para>
+         De-register the clients using their client IDs:
+       </para>
+<screen>&prompt.root;<command>smt-delete-registration -g <replaceable>CLIENT_ID</replaceable></command></screen>
+       <para>
+         To de-register multiple clients, you can use the <option>-g</option> option multiple times
+         in the same command.
+       </para>
+     </step>
+   </procedure>
+
+   <itemizedlist>
+    <title>Related information</title>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/book-rmt.html">
+      <citetitle>&rmtguide;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with RMT</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 8 or CentOS Linux 8 with RMT</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 9 with RMT</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/suma/en/suse-manager/client-configuration/clients-sleses.html">
+        <citetitle>&suma; Client Configuration Guide: Registering &sliberty; Clients</citetitle></link>
+      </para>
+    </listitem>
+   </itemizedlist>
+ </section>
+
+ <!--section xml:id="introduction-quickstart-smt">
   <title>Introduction</title>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.
@@ -127,7 +218,6 @@
      </para>
     </listitem>
    </orderedlist>
-   <!-- Can delete this if/when all names have been changed-->
    <note>
     <title><emphasis>&productname;</emphasis> and <emphasis>&sles; with Expanded Support</emphasis></title>
     <para>
@@ -268,6 +358,6 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </section>
+ </section-->
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2024-07-01</date>
+      <revdescription>
+        <para>
+          Updates for LTSS.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-06-27</date>
       <revdescription>
         <para>
@@ -80,10 +88,27 @@
 
  <section xml:id="introduction-quickstart">
   <title>Introduction</title>
+   <important>
+     <title>End of general support for &productname; &productnumber;</title>
+     <para>
+       &productname; &productnumber; has reached the end of general support and is now in LTSS
+       (Long Term Service Support).
+     </para>
+     <para>
+       If you have a <emphasis>&productname;</emphasis> subscription but do not have an
+       <emphasis>LTSS</emphasis> subscription, you can continue to use your systems. However,
+       registering new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
+       systems with the general subscription is no longer supported.
+     </para>
+     <para>
+       To register new systems, you must use a <emphasis>&productname; LTSS &productnumber;</emphasis>
+       subscription.
+     </para>
+   </important>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.
     With a &productname; subscription, you can register and receive updates for
-    &rhel;, CentOS Linux, and &sles;. An optional &ha; extension is also available.
+    &rhel;, CentOS Linux, and &sles;.
    </para>
    <important role="compact">
     <para>
@@ -95,11 +120,6 @@
     following tools:
    </para>
    <itemizedlist>
-     <listitem>
-       <para>
-         &smtool; (&smt;)
-       </para>
-     </listitem>
      <listitem>
        <para>
          &rmtool; (&rmt;)
@@ -128,7 +148,7 @@
     <listitem>
      <para>
       If you already have an &rmt; server but still need to <emphasis role="bold">mirror the
-      &productname;&nbsp;&productnumber; repositories</emphasis>, go to
+      &reponame;&nbsp;&productnumber; repositories</emphasis>, go to
       <xref linkend="mirror-repositories-with-rmt"/>.
      </para>
     </listitem>
@@ -157,12 +177,6 @@
      <para>
       <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/book-rmt.html">
       <citetitle>&rmtguide;</citetitle></link>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart-smt/art-quickstart-smt.html">
-      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with SMT</citetitle></link>
      </para>
     </listitem>
     <listitem>
@@ -229,7 +243,7 @@
       </listitem>
     </varlistentry>
     <varlistentry>
-      <term>Setup script cannot access the &productname; repository</term>
+      <term>Setup script cannot access the &productname; repositories</term>
       <listitem>
       <para>
         The <filename>repodata</filename> directory on the &rmt; server will not

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -101,8 +101,8 @@
        systems with the general subscription is no longer supported.
      </para>
      <para>
-       To register new systems, you must use a <emphasis>&productname; LTSS &productnumber;</emphasis>
-       subscription.
+       To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber; systems, and to continue receiving new updates for existing systems, you must purchase a
+       <emphasis>&productname; LTSS &productnumber;</emphasis> subscription.
      </para>
    </important>
    <para>
@@ -116,21 +116,9 @@
     </para>
    </important>
    <para>
-    You can register &rhla; &productnumber; or CentOS Linux &productnumber; with one of the
-    following tools:
+    You can register &rhla; &productnumber; or CentOS Linux &productnumber; with either
+    &suma; or the &rmtool; (&rmt;).
    </para>
-   <itemizedlist>
-     <listitem>
-       <para>
-         &rmtool; (&rmt;)
-       </para>
-     </listitem>
-     <listitem>
-       <para>
-         &suma;
-       </para>
-     </listitem>
-   </itemizedlist>
    <para>
     This guide describes how to register with an &rmt; server. &rmt; is a proxy system for the
     &scc;. The &rmt; server is registered with the &scc;, and other systems in the network are
@@ -289,5 +277,6 @@
     </varlistentry>
   </variablelist>
  </section>
+ <xi:include href="app-temp-script.xml"/>
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -101,8 +101,19 @@
        systems with the general subscription is no longer supported.
      </para>
      <para>
-       To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber; systems, and to continue receiving new updates for existing systems, you must purchase a
-       <emphasis>&productname; LTSS &productnumber;</emphasis> subscription.
+       To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
+       systems, and to continue receiving new updates for existing systems, you must purchase a
+       <emphasis>&reponame; &productnumber;</emphasis> subscription.
+     </para>
+     <para>
+       Additionally, the optional &ha; extension is no longer supported with
+       &reponame; &productnumber;. You must remove this product from your system
+       before you can register with an LTSS subscription.
+     </para>
+     <para>
+       If you previously registered your systems with a general subscription and want to move
+       them to an LTSS subscription, see <xref linkend="mirror-repositories-with-rmt"/>
+       and <xref linkend="register-7-with-rmt"/>.
      </para>
    </important>
    <para>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -102,7 +102,7 @@
      </para>
      <para>
        To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
-       systems, and to continue receiving new updates for existing systems, you must purchase a
+       systems, <!--and to continue receiving new updates for existing systems, -->you must purchase a
        <emphasis>&reponame; &productnumber;</emphasis> subscription.
      </para>
      <para>
@@ -110,11 +110,11 @@
        &reponame; &productnumber;. You must remove this product from your system
        before you can register with an LTSS subscription.
      </para>
-     <para>
+     <!--para>
        If you previously registered your systems with a general subscription and want to move
        them to an LTSS subscription, see <xref linkend="mirror-repositories-with-rmt"/>
        and <xref linkend="register-7-with-rmt"/>.
-     </para>
+     </para-->
    </important>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.

--- a/xml/html/rh-art-lite-quickstart.html
+++ b/xml/html/rh-art-lite-quickstart.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
-<meta name="description" content="Initial release."/>
+<meta name="description" content="Updates for LTSS."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="book-title" content="Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="chapter-title" content="Revision History"/>
@@ -40,7 +40,7 @@
       }
     ],
       
-    "dateModified": "2024-06-18T00:00+02:00",
+    "dateModified": "2024-07-01T00:00+02:00",
       
     "datePublished": "2024-06-18T00:00+02:00",
       
@@ -82,7 +82,11 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</h1><section class="revision"><h2><span class="revision date">2024-06-18</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</h1><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
+        <p>
+          Updates for LTSS.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-06-18</span></h2>
         <p>
           Initial release.
         </p>

--- a/xml/html/rh-art-quickstart.html
+++ b/xml/html/rh-art-quickstart.html
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with SMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
-<meta name="description" content="Retire guide for LTSS."/>
+<meta name="description" content="Updates for LTSS."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
-<meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with SMT"/>
+<meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with RMT"/>
 <meta name="chapter-title" content="Revision History"/>
 <meta name="tracker-url" content="https://github.com/SUSE/doc-liberty/issues/new"/>
 <meta name="tracker-type" content="gh"/>
@@ -42,7 +42,7 @@
       
     "dateModified": "2024-07-01T00:00+02:00",
       
-    "datePublished": "2022-04-01T00:00+02:00",
+    "datePublished": "2024-03-14T00:00+02:00",
       
 
     "about": [
@@ -82,15 +82,23 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with SMT</h1><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
         <p>
-          Retire guide for LTSS.
+          Updates for LTSS.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-06-27</span></h2>
+        <p>
+          Add Minimal VM procedure.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-05-10</span></h2>
+        <p>
+          RMT script and requirements update.
         </p>
       </section><section class="revision"><h2><span class="revision date">2024-03-27</span></h2>
         <p>
           Clarify wording of requirements.
         </p>
-      </section><section class="revision"><h2><span class="revision date">2022-04-01</span></h2>
+      </section><section class="revision"><h2><span class="revision date">2024-03-14</span></h2>
         <p>
           Initial release.
         </p>

--- a/xml/html/rh-art-quickstart.html
+++ b/xml/html/rh-art-quickstart.html
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
+<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with SMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
-<meta name="description" content="Add Minimal VM procedure."/>
+<meta name="description" content="Retire guide for LTSS."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
-<meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with RMT"/>
+<meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with SMT"/>
 <meta name="chapter-title" content="Revision History"/>
 <meta name="tracker-url" content="https://github.com/SUSE/doc-liberty/issues/new"/>
 <meta name="tracker-type" content="gh"/>
@@ -40,9 +40,9 @@
       }
     ],
       
-    "dateModified": "2024-06-27T00:00+02:00",
+    "dateModified": "2024-07-01T00:00+02:00",
       
-    "datePublished": "2024-03-14T00:00+02:00",
+    "datePublished": "2022-04-01T00:00+02:00",
       
 
     "about": [
@@ -82,19 +82,15 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-06-27</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with SMT</h1><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
         <p>
-          Add Minimal VM procedure.
-        </p>
-      </section><section class="revision"><h2><span class="revision date">2024-05-10</span></h2>
-        <p>
-          RMT script and requirements update.
+          Retire guide for LTSS.
         </p>
       </section><section class="revision"><h2><span class="revision date">2024-03-27</span></h2>
         <p>
           Clarify wording of requirements.
         </p>
-      </section><section class="revision"><h2><span class="revision date">2024-03-14</span></h2>
+      </section><section class="revision"><h2><span class="revision date">2022-04-01</span></h2>
         <p>
           Initial release.
         </p>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -63,14 +63,17 @@
         We recommend at least 1.5 times the total size of all enabled repositories.
       </para>
       <important>
-<!-- trichardson 2024-06-18: TO DO: New streamlined repos will be available from July 1 -->
         <title>&reponame; &productnumber; repository size</title>
         <para>
-          The &reponame; repositories will grow substantially over time, because older package
+          The &reponame; repositories will grow over time, because older package
           versions are not removed. To meet the 1.5x size recommendation, based on the
-          current<footnote><para>As of 20 June, 2024</para></footnote>
-          size of the &reponame; &productnumber; repository, you will need approximately 710&nbsp;GB
+          current<footnote><para>As of 01 July, 2024</para></footnote> size of the default
+          &reponame; &productnumber; repositories, you will need approximately 225&nbsp;GB
           of disk space available for the &rmt; server.
+        </para>
+        <para>
+          If you also need the <literal>Source</literal> and <literal>Debug</literal>
+          repositories, you will need an additional 765&nbsp;GB available.
         </para>
       </important>
     </listitem>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -55,11 +55,12 @@
      one default repository and one optional <literal>Source</literal> repository. Now there are
      two default repositories, <literal>BASE</literal> and <literal>LTSS</literal>, along with
      optional <literal>Source</literal> and <literal>Debug</literal> repositories for both.
-   </para>
-   <para>
      The <literal>BASE</literal> repositories are frozen and contain the existing packages from
      the original &productname; repositories. The <literal>LTSS</literal> repositories contain
      new packages for &reponame; &productnumber;.
+   </para>
+   <para>
+     There are no new &ha; repositories. &ha; is not supported with &reponame; &productnumber;.
    </para>
    <para>
     If you previously mirrored the &productname; repositories with the general subscription,
@@ -71,6 +72,12 @@
          Disable the original product. This also disables any repositories associated with the product:
        </para>
 <screen>&prompt.root;<command>rmt-cli product disable 1251</command></screen>
+     </listitem>
+     <listitem>
+       <para>
+         If your previous subscription included the &ha; extension, disable this product too:
+       </para>
+<screen>&prompt.root;<command>rmt-cli product disable 1252</command></screen>
      </listitem>
      <listitem>
        <para>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -71,19 +71,6 @@
     This enables all the default repositories associated with the product.
    </para>
   </step>
-  <step audience="sll">
-   <para>
-    If your subscription includes the &ha; extension, enable the extension using
-    the product ID <literal>1252</literal>:
-   </para>
-<screen>&prompt.root;<command>rmt-cli product enable 1252</command></screen>
-   <tip role="compact">
-    <para>
-     To check whether the &ha; extension is available, run this command:
-     <command>rmt-cli products list --all --name="Liberty" --version=&productnumber;</command>
-    </para>
-   </tip>
-  </step>
   <step>
    <para>
     If you also need the <literal>Source</literal> repository, find and enable it with the

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -62,7 +62,7 @@
    <para>
      There are no new &ha; repositories. &ha; is not supported with &reponame; &productnumber;.
    </para>
-   <para>
+   <!--para>
     If you previously mirrored the &productname; repositories with the general subscription,
     clean up these repositories first before you start mirroring the new LTSS repositories:
    </para>
@@ -85,7 +85,7 @@
        </para>
 <screen>&prompt.root;<command>rmt-cli repos clean</command></screen>
      </listitem>
-   </orderedlist>
+   </orderedlist-->
  </important>
 
  <procedure xml:id="pro-mirror-repositories-with-rmt">

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -33,7 +33,7 @@
     The &rmt; server has enough storage available for repository mirroring. The amount of storage
     required depends on the number of repositories you mirror. We recommend at least 1.5 times
     the total size of all enabled repositories. Be aware that the &reponame; repositories will
-    grow substantially over time.
+    grow over time.
    </para>
   </listitem>
   <listitem>
@@ -47,6 +47,39 @@
    </para>
   </listitem>
  </itemizedlist>
+
+ <important audience="sll">
+   <title>New repository structure for &reponame; &productnumber;</title>
+   <para>
+     The repository structure has changed in &reponame; &productnumber;. Previously, there was
+     one default repository and one optional <literal>Source</literal> repository. Now there are
+     two default repositories, <literal>BASE</literal> and <literal>LTSS</literal>, along with
+     optional <literal>Source</literal> and <literal>Debug</literal> repositories for both.
+   </para>
+   <para>
+     The <literal>BASE</literal> repositories are frozen and contain the existing packages from
+     the original &productname; repositories. The <literal>LTSS</literal> repositories contain
+     new packages for &reponame; &productnumber;.
+   </para>
+   <para>
+    If you previously mirrored the &productname; repositories with the general subscription,
+    clean up these repositories first before you start mirroring the new LTSS repositories:
+   </para>
+   <orderedlist>
+     <listitem>
+       <para>
+         Disable the original product. This also disables any repositories associated with the product:
+       </para>
+<screen>&prompt.root;<command>rmt-cli product disable 1251</command></screen>
+     </listitem>
+     <listitem>
+       <para>
+         Free up space on the server by cleaning up the files associated with the disabled repositories:
+       </para>
+<screen>&prompt.root;<command>rmt-cli repos clean</command></screen>
+     </listitem>
+   </orderedlist>
+ </important>
 
  <procedure xml:id="pro-mirror-repositories-with-rmt">
   <title>Mirroring the &reponame; repositories with &rmt;</title>
@@ -64,19 +97,20 @@
   </step>
   <step>
    <para>
-    Enable &reponame; &productnumber; using the product ID <literal>1251</literal>:
+    Enable &reponame; &productnumber; using the product ID <literal>2702</literal>:
    </para>
-<screen>&prompt.root;<command>rmt-cli product enable 1251</command></screen>
+<screen>&prompt.root;<command>rmt-cli product enable 2702</command></screen>
    <para>
     This enables all the default repositories associated with the product.
    </para>
   </step>
   <step>
    <para>
-    If you also need the <literal>Source</literal> repository, find and enable it with the
-    following commands:
+    If you also need the <literal>Source</literal> or <literal>Debug </literal>repositories,
+    find and enable them with the following commands:
    </para>
-<screen>&prompt.root;<command>rmt-cli repo list --all | grep RES-</command>
+<screen>&prompt.root;<command>rmt-cli repo list --all | grep RES-7-BASE</command>
+&prompt.root;<command>rmt-cli repo list --all | grep RES-7-LTSS</command>
 &prompt.root;<command>rmt-cli repo enable <replaceable>REPO_ID</replaceable></command></screen>
   </step>
   <step>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -3,7 +3,7 @@
 <!ENTITY productnameshort       "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase audience='sll'>SLL</phrase><phrase audience='sll-l'>SLL-L</phrase></phrase>">
 <!ENTITY productnumber          "7">
 
-<!ENTITY reponame               "SUSE Liberty Linux">
+<!ENTITY reponame               "SUSE Liberty Linux LTSS">
 
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url               "https://github.com/SUSE/doc-liberty">

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -71,7 +71,7 @@
   </listitem>
  </itemizedlist>
 
- <important audience="sll">
+ <!--important audience="sll">
    <title>New registration setup for &reponame; &productnumber;</title>
    <para>
     The repository structure and registration setup has changed in &reponame; &productnumber;.
@@ -81,12 +81,12 @@
    <para>
     To de-register your system, run the following command:
    </para>
-<screen>&prompt.root;<command>SUSEConnect --de-register</command></screen>
+<screen>&prompt.root;<command>SUSEConnect -/-de-register</command></screen>
    <para>
      This command also removes the &ha; extension if it was installed on your system.
      &ha; is not supported with &reponame; &productnumber;.
    </para>
- </important>
+ </important-->
 
  <procedure xml:id="pro-register-rhel-with-rmt">
   <title>Registering <phrase audience="sll">&rhla; or </phrase>CentOS Linux with &rmt;</title>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -154,19 +154,6 @@ Installed Products:
     You should see <literal>RES-&productnumber;-Updates</literal>.
    </para>
   </step>
-  <step audience="sll">
-   <para>
-    If your subscription includes the &ha; extension, activate it with the
-    following command:
-   </para>
-<screen>&prompt.root;<command>&suseconnect; -p RES-HA/&productnumber;/x86_64</command></screen>
-   <tip role="compact">
-    <para>
-     To check whether the extension is available, run the
-     <command>&suseconnect; --list-extensions</command> command.
-    </para>
-   </tip>
-  </step>
   <step>
    <para>
     Run the update command to make sure there are no errors:

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -70,13 +70,30 @@
    </para>
   </listitem>
  </itemizedlist>
+
+ <important audience="sll">
+   <title>New registration setup for &reponame; &productnumber;</title>
+   <para>
+    The repository structure and registration setup has changed in &reponame; &productnumber;.
+    If you previously registered your system with a general &productname; subscription,
+    de-register your system from the original subscription and re-register with the LTSS subscription.
+   </para>
+   <para>
+    To de-register your system, run the following command:
+   </para>
+<screen>&prompt.root;<command>SUSEConnect --de-register</command></screen>
+ </important>
+
  <procedure xml:id="pro-register-rhel-with-rmt">
   <title>Registering <phrase audience="sll">&rhla; or </phrase>CentOS Linux with &rmt;</title>
-  <step>
+  <step><!-- Temporary script until the new one is available from RMT
    <para>
     Download the <filename>rmt-client-setup-res</filename> script:
    </para>
-<screen>&prompt.root;<command>curl http://<replaceable>RMT_SERVER</replaceable>/tools/rmt-client-setup-res --output rmt-client-setup-res</command></screen>
+<screen>&prompt.root;<command>curl http://<replaceable>RMT_SERVER</replaceable>/tools/rmt-client-setup-res -/-output rmt-client-setup-res</command></screen-->
+   <para>
+    Save the script in <xref linkend="app-temp-script"/> as <filename>rmt-client-setup-res</filename>.
+   </para>
   </step>
   <step>
    <para>
@@ -137,8 +154,8 @@
 Installed Products:
 ------------------------------------------
 
-  SLES Expanded Support platform release file
-  (RES/&productnumber;/x86_64)
+  SUSE Liberty Linux release file
+  (RES-LTSS/&productnumber;/x86_64)
 
   Registered
 
@@ -151,7 +168,8 @@ Installed Products:
    </para>
 <screen>&prompt.root;<command>yum repolist</command></screen>
    <para>
-    You should see <literal>RES-&productnumber;-Updates</literal>.
+    You should see <literal>RES-&productnumber;-BASE-Updates</literal> and
+    <literal>RES-&productnumber;-LTSS-Updates</literal>.
    </para>
   </step>
   <step>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -82,6 +82,10 @@
     To de-register your system, run the following command:
    </para>
 <screen>&prompt.root;<command>SUSEConnect --de-register</command></screen>
+   <para>
+     This command also removes the &ha; extension if it was installed on your system.
+     &ha; is not supported with &reponame; &productnumber;.
+   </para>
  </important>
 
  <procedure xml:id="pro-register-rhel-with-rmt">


### PR DESCRIPTION
### PR creator: Description

The SLL7 guides needed some updates for LTSS. 

* I've reduced the SMT guide down to a stub stating it is not supported, and linking to a procedure to migrate to RMT.
* I've updated the Lite guide with the new repos, but I haven't added all the Important boxes as it was already an LTSS product. 
* The new RMT script isn't available yet, so I've added it directly to the guide. It's quite long this time so I added it to an appendix that we can reuse whenever this is needed.
* Re-registration might not be working as expected so I've temporarily commented out those parts of the warnings. But they are there in the diff, and will be quick to add when it's ready.

PDFs:

Main RMT guide: 
[art-quickstart_en.pdf](https://github.com/user-attachments/files/16050387/art-quickstart_en.pdf)

Lite guide:
[art-lite-quickstart_en.pdf](https://github.com/user-attachments/files/16050393/art-lite-quickstart_en.pdf)

SMT guide:
[art-quickstart-smt_en.pdf](https://github.com/user-attachments/files/16050378/art-quickstart-smt_en.pdf)

### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #SLL-363


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
