### PR TITLE
Update LTSS 7 registration script

### DIFF
--- a/xml/app-temp-script.xml
+++ b/xml/app-temp-script.xml
@@ -24,7 +24,7 @@
   is shown here. Save this script as <filename>rmt-client-setup-res</filename>.
  </para>
 
-<screen>#!/bin/sh
+<screen>#!/bin/bash
 
 SUSECONNECT=/usr/bin/SUSEConnect
 RPM=/usr/bin/rpm
@@ -139,7 +139,7 @@ else
     CERTURL="$REGCERT"
 fi
 
-$CURL --tlsv1.2 --silent --insecure --connect-timeout 10 --output $TEMPFILE $CERTURL
+$CURL --tlsv1.2 --silent --insecure --connect-timeout 10 --output "$TEMPFILE" "$CERTURL"
 if [ $? -ne 0 ]; then
     echo "Download failed. Abort."
     exit 1
@@ -183,14 +183,12 @@ echo "Detected ${SLL_name} version: ${SLL_version}"
 
 echo "Importing repomd.xml.key"
 if [[ ${SLL_version} -eq 7 ]]; then
-  $CURL --silent --show-error --insecure ${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+  $CURL --silent --show-error --insecure "${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update/repodata/repomd.xml.key" --output repomd.xml.key
 else
-  $CURL --silent --show-error --insecure ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key --output repomd.xml.key
+  $CURL --silent --show-error --insecure "${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update/repodata/repomd.xml.key" --output repomd.xml.key
 fi
 $RPM --import repomd.xml.key
 
-if [ ! -x $SUSECONNECT ]; then
-    echo "Downloading SUSEConnect"
 if [[ ${SLL_version} -gt 7 ]]; then
 
     if [ ! -x $DNF ]; then
@@ -200,14 +198,13 @@ if [[ ${SLL_version} -gt 7 ]]; then
 
     echo "Disabling all repositories"
     $DNF config-manager --disable $(dnf repolist -q | awk '{ print $1 }' | grep -v repo)
-    # sed -i 's/^enabled=1/enabled=0/' /etc/yum.repos.d/*
     # on RHEL9 (not RHEL8) redhat-release is protected and cannot be updated to sll-release
     if [ -f /etc/dnf/protected.d/redhat-release.conf ]; then
        rm -f /etc/dnf/protected.d/redhat-release.conf
     fi
 
-    $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update
-    $DNF config-manager --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update
+    $DNF config-manager --add-repo "${REGURL}/repo/SUSE/Updates/${SLL_name}/${SLL_version}/x86_64/update"
+    $DNF config-manager --add-repo "${REGURL}/repo/SUSE/Updates/${SLL_name}-AS/${SLL_version}/x86_64/update"
     $DNF install -y --allowerasing ${SLL_release_package}
 
     # For RHEL8/CentOS8, remove all old signing keys and import SUSE keys installed with sles_es-release package
@@ -215,7 +212,9 @@ if [[ ${SLL_version} -gt 7 ]]; then
         import_rpm_signing_keys
     fi
 
+    echo "Downloading SUSEConnect"
     $DNF install SUSEConnect librepo
+
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}_${SLL_version}_x86_64_update"
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
 
@@ -235,25 +234,30 @@ elif [[ ${SLL_version} -eq 7 ]]; then
        rm -f /usr/share/redhat-release
     fi
 
-    $YUM_CONFIG_MGR --add-repo ${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update
+    $YUM_CONFIG_MGR --add-repo "${REGURL}/repo/SUSE/Updates/${SLL_name%%-LTSS}/${SLL_version}-LTSS/x86_64/update"
     if [ ${SLL_name} = "RES-OL-LTSS" ]; then
-    	$YUM_CONFIG_MGR --add-repo ${REGURL}/repo/SUSE/Updates/RES-BASE/${SLL_version}/x86_64/update
+    	$YUM_CONFIG_MGR --add-repo "${REGURL}/repo/SUSE/Updates/RES-BASE/${SLL_version}/x86_64/update"
     fi
     $YUM_CONFIG_MGR --enable *suse.* &gt; /dev/null
 
-    $YUM install -y ${SLL_release_package} suseconnect-ng librepo
+    if [ ! -x $SUSECONNECT ]; then
+        $YUM install -y ${SLL_release_package} suseconnect-ng librepo
+    else
+        $YUM update -y ${SLL_release_package} suseconnect-ng librepo
+    fi
+
     $YUM update -y yum
     $YUM_CONFIG_MGR --disable \* &gt; /dev/null
-fi
+
 elif [[ ${SLL_version} -eq 8 ]]; then
     # For SLL8, the release package is already installed, just import the keys
     import_rpm_signing_keys
 fi
 
-$CURL --silent --show-error --insecure $REGURL/tools/rmt-client-setup --output rmt-client-setup
+$CURL --silent --show-error --insecure "$REGURL/tools/rmt-client-setup" --output rmt-client-setup
 echo "Running rmt-client-setup $PARAMS"
 if [ -n "$YES_PARAM" ]; then
-    PARAMS=$(echo $PARAMS | sed 's/--yes//')
+    PARAMS=$(echo "$PARAMS" | sed 's/--yes//')
     yes | sh rmt-client-setup $PARAMS
 else
     sh rmt-client-setup $PARAMS

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -102,7 +102,7 @@
      </para>
      <para>
        To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
-       systems, <!--and to continue receiving new updates for existing systems, -->you must purchase a
+       systems, and to continue receiving new updates for existing systems, you must purchase a
        <emphasis>&reponame; &productnumber;</emphasis> subscription.
      </para>
      <para>
@@ -110,11 +110,11 @@
        &reponame; &productnumber;. You must remove this product from your system
        before you can register with an LTSS subscription.
      </para>
-     <!--para>
+     <para>
        If you previously registered your systems with a general subscription and want to move
        them to an LTSS subscription, see <xref linkend="mirror-repositories-with-rmt"/>
        and <xref linkend="register-7-with-rmt"/>.
-     </para-->
+     </para>
    </important>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -62,14 +62,14 @@
    <para>
      There are no new &ha; repositories. &ha; is not supported with &reponame; &productnumber;.
    </para>
-   <!--para>
+   <para>
     If you previously mirrored the &productname; repositories with the general subscription,
     clean up these repositories first before you start mirroring the new LTSS repositories:
    </para>
    <orderedlist>
      <listitem>
        <para>
-         Disable the original product. This also disables any repositories associated with the product:
+         Disable the original product. This also disables all repositories associated with the product:
        </para>
 <screen>&prompt.root;<command>rmt-cli product disable 1251</command></screen>
      </listitem>
@@ -78,6 +78,9 @@
          If your previous subscription included the &ha; extension, disable this product too:
        </para>
 <screen>&prompt.root;<command>rmt-cli product disable 1252</command></screen>
+       <para>
+         &ha; is not supported with &reponame; &productnumber;.
+       </para>
      </listitem>
      <listitem>
        <para>
@@ -85,7 +88,7 @@
        </para>
 <screen>&prompt.root;<command>rmt-cli repos clean</command></screen>
      </listitem>
-   </orderedlist-->
+   </orderedlist>
  </important>
 
  <procedure xml:id="pro-mirror-repositories-with-rmt">

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -71,22 +71,33 @@
   </listitem>
  </itemizedlist>
 
- <!--important audience="sll">
+ <important audience="sll">
    <title>New registration setup for &reponame; &productnumber;</title>
    <para>
     The repository structure and registration setup has changed in &reponame; &productnumber;.
     If you previously registered your system with a general &productname; subscription,
-    de-register your system from the original subscription and re-register with the LTSS subscription.
+    de-register your system from the original subscription before you re-register
+    with the LTSS subscription:
    </para>
-   <para>
-    To de-register your system, run the following command:
-   </para>
-<screen>&prompt.root;<command>SUSEConnect -/-de-register</command></screen>
-   <para>
-     This command also removes the &ha; extension if it was installed on your system.
-     &ha; is not supported with &reponame; &productnumber;.
-   </para>
- </important-->
+   <orderedlist>
+     <listitem>
+       <para>
+         De-register your system:
+       </para>
+<screen>&prompt.root;<command>SUSEConnect --de-register</command></screen>
+       <para>
+        This command also removes the &ha; extension if it was installed on your system.
+        &ha; is not supported with &reponame; &productnumber;.
+      </para>
+     </listitem>
+     <listitem>
+       <para>
+         Clean up the registration status:
+       </para>
+<screen>&prompt.root;<command>SUSEConnect --cleanup</command></screen>
+     </listitem>
+   </orderedlist>
+ </important>
 
  <procedure xml:id="pro-register-rhel-with-rmt">
   <title>Registering <phrase audience="sll">&rhla; or </phrase>CentOS Linux with &rmt;</title>


### PR DESCRIPTION
### PR creator: Description

Lőrinc has updated the registration script to make it work better for SLL 7 -> SLL LTSS 7 registrations. I've therefore updated the script in the appendix, and uncommented the additional  content in the `Important` admonitions now that it applies.

PDF: 
[art-quickstart_en.pdf](https://github.com/user-attachments/files/16092087/art-quickstart_en.pdf)


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #SLL-368


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
