### PR TITLE
New script to fix yum-utils issue

### DIFF
--- a/xml/app-temp-script.xml
+++ b/xml/app-temp-script.xml
@@ -219,10 +219,20 @@ if [[ ${SLL_version} -gt 7 ]]; then
     $DNF config-manager --set-disabled "${RMTNAME}_repo_SUSE_Updates_${SLL_name}-AS_${SLL_version}_x86_64_update"
 
 elif [[ ${SLL_version} -eq 7 ]]; then
-    # For SLL7 we need to have yum, yum_config_mgr, sles_os-release-server, etc..
-    if [ ! -x "$YUM_CONFIG_MGR" ]; then
-        echo "YUM config manager is not installed. Please install yum-config-manager and retry. Abort."
-        exit 1
+
+    # disable unavailable centos mirrors
+    sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+    sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+    sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
+    # Check for and install yum-config-manager if not available
+    if [ ! -x $YUM_CONFIG_MGR ]; then
+        echo "yum-config-manager not found. Attempting to install."
+        $YUM install -y yum-utils
+        if [ $? -ne 0 ]; then
+            echo "Failed to install yum-config-manager. Abort."
+            exit 1
+        fi
     fi
 
     echo "Disabling all repositories"
@@ -241,14 +251,15 @@ elif [[ ${SLL_version} -eq 7 ]]; then
     $YUM_CONFIG_MGR --enable *suse.* &gt; /dev/null
 
     if [ ! -x $SUSECONNECT ]; then
-        $YUM install -y ${SLL_release_package} suseconnect-ng librepo
+        $YUM install -y --nogpgcheck ${SLL_release_package}
+        import_rpm_signing_keys
+        $YUM install -y suseconnect-ng librepo
     else
         $YUM update -y ${SLL_release_package} suseconnect-ng librepo
     fi
 
     $YUM update -y yum
     $YUM_CONFIG_MGR --disable \* &gt; /dev/null
-
 elif [[ ${SLL_version} -eq 8 ]]; then
     # For SLL8, the release package is already installed, just import the keys
     import_rpm_signing_keys

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-lite-quickstart">
     <revision>
+      <date>2024-07-08</date>
+      <revdescription>
+        <para>
+          Registration script now installs <package>yum-utils</package>.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-07-01</date>
       <revdescription>
         <para>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2024-07-08</date>
+      <revdescription>
+        <para>
+          Registration script now installs <package>yum-utils</package>.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-07-01</date>
       <revdescription>
         <para>

--- a/xml/html/rh-art-lite-quickstart.html
+++ b/xml/html/rh-art-lite-quickstart.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
-<meta name="description" content="Updates for LTSS."/>
+<meta name="description" content="Registration script now installs yum-utils."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="book-title" content="Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="chapter-title" content="Revision History"/>
@@ -40,7 +40,7 @@
       }
     ],
       
-    "dateModified": "2024-07-01T00:00+02:00",
+    "dateModified": "2024-07-08T00:00+02:00",
       
     "datePublished": "2024-06-18T00:00+02:00",
       
@@ -82,7 +82,11 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</h1><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-lite-quickstart"><h1 class="title">Revision History: Registering CentOS Linux 7 with SUSE Liberty LinuxSUSE Liberty Linux Lite</h1><section class="revision"><h2><span class="revision date">2024-07-08</span></h2>
+        <p>
+          Registration script now installs <span class="package">yum-utils</span>.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
         <p>
           Updates for LTSS.
         </p>

--- a/xml/html/rh-art-quickstart.html
+++ b/xml/html/rh-art-quickstart.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head><title>Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</title><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes"/><link rel="stylesheet" type="text/css" href="static/css/style.css"/>
 <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/"/><link rel="schema.DCTERMS" href="http://purl.org/dc/terms/"/>
 <meta name="title" content="Revision History | SLLSLL-L"/>
-<meta name="description" content="Updates for LTSS."/>
+<meta name="description" content="Registration script now installs yum-utils."/>
 <meta name="product-name" content="SUSE Liberty LinuxSUSE Liberty Linux Lite"/>
 <meta name="book-title" content="Registering RHEL 7 or CentOS Linux 7 with RMT"/>
 <meta name="chapter-title" content="Revision History"/>
@@ -40,7 +40,7 @@
       }
     ],
       
-    "dateModified": "2024-07-01T00:00+02:00",
+    "dateModified": "2024-07-08T00:00+02:00",
       
     "datePublished": "2024-03-14T00:00+02:00",
       
@@ -82,7 +82,11 @@ hljs.configure({
   useBR: false
 });
 
-</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
+</script></head><body><div class="revhistory" id="rh-art-quickstart"><h1 class="title">Revision History: Registering RHEL 7 or CentOS Linux 7 with RMT</h1><section class="revision"><h2><span class="revision date">2024-07-08</span></h2>
+        <p>
+          Registration script now installs <span class="package">yum-utils</span>.
+        </p>
+      </section><section class="revision"><h2><span class="revision date">2024-07-01</span></h2>
         <p>
           Updates for LTSS.
         </p>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -52,13 +52,6 @@
    </para>
   </listitem>
   <listitem>
-    <para>
-      The package <package>yum-utils</package> is installed on the system you want to register.
-      This package is installed by default in most installations, but not in a
-      <literal>Minimal Install</literal>.
-    </para>
-  </listitem>
-  <listitem>
    <para>
     You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
    </para>


### PR DESCRIPTION
### PR creator: Description

`yum-utils` can't be installed from the old CentOS 7 repos anymore, but can be from the CentOS vault. The registration script now handles this. 


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #SLL-369


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
