### PR TITLE
More info about default and optional repos

### DIFF
--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -207,6 +207,44 @@
       </orderedlist>
       </listitem>
     </varlistentry>
+    <varlistentry>
+      <term><command>yum update</command> fails with <literal>[Errno 14] HTTPS Error 404 - Not Found</literal></term>
+      <listitem>
+        <para>
+          The repository shown in the error message might not be mirrored on the &rmt; server.
+          The optional <literal>BASE</literal>, <literal>Source</literal> and <literal>Debug</literal>
+          repositories can be enabled with <command>yum-config-manager</command> even if they are
+          not available from &rmt;.
+        </para>
+        <para>
+        </para>
+        <orderedlist>
+          <listitem>
+            <para>
+              Run <command>yum repolist all</command> to show the status of the repositories.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If the repository shown in the error message has the status
+              <literal>enabled</literal>, disable it with the following command:
+            </para>
+<screen>&prompt.root;<command>yum-config-manager --disable <replaceable>REPO_ID</replaceable></command></screen>
+          </listitem>
+          <listitem>
+            <para>
+              Run <command>yum update</command> again to see if the issue is resolved.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If you need the unavailable repository for your system, see
+              <xref linkend="mirror-repositories-with-rmt"/>.
+            </para>
+          </listitem>
+        </orderedlist>
+      </listitem>
+    </varlistentry>
   </variablelist>
  </section>
  <!--xi:include href="app-temp-script.xml"/-->

--- a/xml/art-lite-quickstart.xml
+++ b/xml/art-lite-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-lite-quickstart">
     <revision>
+      <date>2024-10-18</date>
+      <revdescription>
+        <para>
+          Add more information about default and optional repositories.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-08-01</date>
       <revdescription>
         <para>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -302,6 +302,45 @@
       </orderedlist>
       </listitem>
     </varlistentry>
+    <varlistentry>
+      <term><command>yum update</command> fails with <literal>[Errno 14] HTTPS Error 404 - Not Found</literal></term>
+      <listitem>
+        <para>
+          The repository shown in the error message might not be mirrored on the &rmt; server.
+          The optional <literal>BASE</literal>, <literal>Source</literal> and <literal>Debug</literal>
+          repositories can be enabled with <command>yum-config-manager</command> even if they are
+          not available from &rmt;.
+        </para>
+        <para>
+
+        </para>
+        <orderedlist>
+          <listitem>
+            <para>
+              Run <command>yum repolist all</command> to show the status of the repositories.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If the repository shown in the error message has the status
+              <literal>enabled</literal>, disable it with the following command:
+            </para>
+<screen>&prompt.root;<command>yum-config-manager --disable <replaceable>REPO_ID</replaceable></command></screen>
+          </listitem>
+          <listitem>
+            <para>
+              Run <command>yum update</command> again to see if the issue is resolved.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              If you need the unavailable repository for your system, see
+              <xref linkend="mirror-repositories-with-rmt"/>.
+            </para>
+          </listitem>
+        </orderedlist>
+      </listitem>
+    </varlistentry>
   </variablelist>
  </section>
  <!--xi:include href="app-temp-script.xml"/-->

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -312,7 +312,6 @@
           not available from &rmt;.
         </para>
         <para>
-
         </para>
         <orderedlist>
           <listitem>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -44,6 +44,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2024-10-18</date>
+      <revdescription>
+        <para>
+          Add more information about default and optional repositories.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-08-01</date>
       <revdescription>
         <para>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -65,11 +65,10 @@
       <important>
         <title>&reponame; &productnumber; repository size</title>
         <para>
-          The &reponame; repositories will grow over time because older package
-          versions are not removed. To meet the 1.5x size recommendation, based on the
-          current<footnote><para>As of 17 September, 2024</para></footnote> size of the default
-          &reponame; &productnumber; repositories, you will need approximately 225&nbsp;GB
-          of disk space available for the &rmt; server.
+          The &reponame; repositories will grow over time because older package versions are not
+          removed. Based on the current<footnote><para>As of 17 September, 2024</para></footnote>
+          size of the &reponame; &productnumber; repositories, to meet the 1.5x size recommendation
+          you will need approximately 225&nbsp;GB of disk space available for the &rmt; server.
         </para>
         <para>
           If you also need the <literal>Source</literal> and <literal>Debug</literal>
@@ -149,7 +148,7 @@
       <para>
         If you did not already increase the VM's disk space before the installation began,
         increase it now. You might need to shut down the VM to do so. The VM must have enough
-        space to mirror the &reponame; &productnumber; repository.
+        space to mirror the &reponame; &productnumber; repositories.
       </para>
     </step>
   </procedure>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -65,14 +65,20 @@
       <important>
         <title>&reponame; &productnumber; repository size</title>
         <para>
-          The &reponame; repositories will grow over time because older package versions are not
+          The &reponame; &productnumber; repositories will grow over time because older package versions are not
           removed. Based on the current<footnote><para>As of 17 September, 2024</para></footnote>
-          size of the &reponame; &productnumber; repositories, to meet the 1.5x size recommendation
-          you will need approximately 225&nbsp;GB of disk space available for the &rmt; server.
+          size of the repositories, to meet the 1.5 times size recommendation
+          you will need approximately 15&nbsp;GB of disk space for the default
+          <literal>LTSS-Updates</literal> repository.
+          If you need the optional <literal>LTSS-Source</literal> and <literal>LTSS-Debug</literal>
+         repositories, you will need an additional 39&nbsp;GB.
         </para>
         <para>
-          If you also need the <literal>Source</literal> and <literal>Debug</literal>
-          repositories, you will need an additional 770&nbsp;GB available.
+          &reponame; &productnumber; also has optional frozen <literal>BASE</literal> repositories
+          that contain the packages from the non-LTSS
+          repositories. If you need these repositories, to meet the 1.5 times size recommendation you will need approximately
+          210&nbsp;GB for the <literal>BASE-Updates</literal> repository and 730&nbsp;GB for the
+          <literal>BASE-Source</literal> and <literal>BASE-Debug</literal> repositories.
         </para>
       </important>
     </listitem>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -74,13 +74,13 @@
        <para>
          Disable the original product. This also disables all repositories associated with the product:
        </para>
-<screen>&prompt.root;<command>rmt-cli product disable 1251</command></screen>
+<screen>&prompt.root;<command>rmt-cli products disable 1251</command></screen>
      </listitem>
      <listitem>
        <para>
          If your previous subscription included the &ha; extension, disable this product too:
        </para>
-<screen>&prompt.root;<command>rmt-cli product disable 1252</command></screen>
+<screen>&prompt.root;<command>rmt-cli products disable 1252</command></screen>
        <para>
          &ha; is not supported with &reponame; &productnumber;.
        </para>
@@ -112,7 +112,7 @@
    <para>
     Enable &reponame; &productnumber; using the product ID <literal>2702</literal>:
    </para>
-<screen>&prompt.root;<command>rmt-cli product enable 2702</command></screen>
+<screen>&prompt.root;<command>rmt-cli products enable 2702</command></screen>
    <para>
     This enables the default <literal>RES-7-LTSS-Updates</literal> repository.
    </para>
@@ -127,19 +127,19 @@
        <para>
          <literal>RES-7-BASE-Updates</literal>:
        </para>
-<screen>&prompt.root;<command>rmt-cli repo enable 6986</command></screen>
+<screen>&prompt.root;<command>rmt-cli repos enable 6986</command></screen>
      </listitem>
 <listitem>
        <para>
          <literal>RES-7-LTSS-Source-Updates</literal> and <literal>RES-7-BASE-Source-Updates</literal>:
        </para>
-<screen>&prompt.root;<command>rmt-cli repo enable 6748 6987</command></screen>
+<screen>&prompt.root;<command>rmt-cli repos enable 6748 6987</command></screen>
      </listitem>
      <listitem>
        <para>
          <literal>RES-7-LTSS-Debug-Updates</literal> and <literal>RES-7-BASE-Debug-Updates</literal>:
        </para>
-<screen>&prompt.root;<command>rmt-cli repo enable 6985 6988</command></screen>
+<screen>&prompt.root;<command>rmt-cli repos enable 6985 6988</command></screen>
      </listitem>
    </itemizedlist>
    <tip role="compact">

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -51,13 +51,16 @@
  <important audience="sll">
    <title>New repository structure for &reponame; &productnumber;</title>
    <para>
-     The repository structure has changed in &reponame; &productnumber;. Previously, there was
-     one default repository and one optional <literal>Source</literal> repository. Now there are
-     two default repositories, <literal>BASE</literal> and <literal>LTSS</literal>, along with
-     optional <literal>Source</literal> and <literal>Debug</literal> repositories for both.
-     The <literal>BASE</literal> repositories are frozen and contain the existing packages from
-     the original &productname; repositories. The <literal>LTSS</literal> repositories contain
-     new packages for &reponame; &productnumber;.
+     The repository structure has changed in &reponame; &productnumber;. The non-LTSS subscription
+     had one default repository and one optional <literal>Source</literal> repository. The LTSS
+     subscription has a default <literal>LTSS-Updates</literal> repository, an optional
+     <literal>BASE-Updates</literal> repository, and optional <literal>Source</literal> and
+     <literal>Debug</literal> repositories for both <literal>LTSS</literal> and <literal>BASE</literal>.
+   </para>
+   <para>
+     <literal>BASE</literal> repositories are frozen and contain the existing packages from the
+     non-LTSS repositories. <literal>LTSS</literal> repositories contain new packages for
+     &reponame; &productnumber;.
    </para>
    <para>
      There are no new &ha; repositories. &ha; is not supported with &reponame; &productnumber;.
@@ -111,17 +114,41 @@
    </para>
 <screen>&prompt.root;<command>rmt-cli product enable 2702</command></screen>
    <para>
-    This enables all the default repositories associated with the product.
+    This enables the default <literal>RES-7-LTSS-Updates</literal> repository.
    </para>
   </step>
   <step>
    <para>
-    If you also need the <literal>Source</literal> or <literal>Debug </literal>repositories,
-    find and enable them with the following commands:
+    If you also need the <literal>BASE</literal>, <literal>Source</literal> or
+    <literal>Debug</literal>repositories, enable them with the following commands:
    </para>
-<screen>&prompt.root;<command>rmt-cli repo list --all | grep RES-7-BASE</command>
-&prompt.root;<command>rmt-cli repo list --all | grep RES-7-LTSS</command>
-&prompt.root;<command>rmt-cli repo enable <replaceable>REPO_ID</replaceable></command></screen>
+   <itemizedlist>
+     <listitem>
+       <para>
+         <literal>RES-7-BASE-Updates</literal>:
+       </para>
+<screen>&prompt.root;<command>rmt-cli repo enable 6986</command></screen>
+     </listitem>
+<listitem>
+       <para>
+         <literal>RES-7-LTSS-Source-Updates</literal> and <literal>RES-7-BASE-Source-Updates</literal>:
+       </para>
+<screen>&prompt.root;<command>rmt-cli repo enable 6748 6987</command></screen>
+     </listitem>
+     <listitem>
+       <para>
+         <literal>RES-7-LTSS-Debug-Updates</literal> and <literal>RES-7-BASE-Debug-Updates</literal>:
+       </para>
+<screen>&prompt.root;<command>rmt-cli repo enable 6985 6988</command></screen>
+     </listitem>
+   </itemizedlist>
+   <tip role="compact">
+     <para>
+       <literal>BASE</literal> repositories are frozen and contain the existing packages from the
+       non-LTSS &productname; repositories. <literal>LTSS</literal> repositories contain new
+       packages for &reponame; &productnumber;.
+     </para>
+   </tip>
   </step>
   <step>
    <para>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -175,11 +175,33 @@ Installed Products:
    <para>
     Verify the available repositories:
    </para>
-<screen>&prompt.root;<command>yum repolist</command></screen>
+<screen>&prompt.root;<command>yum repolist all</command></screen>
    <para>
-    You should see <literal>RES-&productnumber;-BASE-Updates</literal> and
-    <literal>RES-&productnumber;-LTSS-Updates</literal>.
+    The default repository <literal>RES-&productnumber;-LTSS-Updates</literal> should be
+    <literal>enabled</literal>.
    </para>
+   <para>
+     You will also see optional <literal>BASE</literal>, <literal>Source</literal> and
+     <literal>Debug</literal> repositories with the status <literal>disabled</literal>.
+     Be aware that these repositories are listed even if they are not mirrored on the &rmt; server.
+     You can check the mirrored repositories by browsing the directory listing at
+     <literal>https://<replaceable>RMT_SERVER</replaceable>/repo/SUSE/Updates/</literal> or by
+     logging in to the &rmt; server and running <command>rmt-cli repos list</command>.
+   </para>
+   <tip role="compact">
+     <para>
+       <literal>BASE</literal> repositories are frozen and contain the existing packages from the
+       non-LTSS &productname; repositories. <literal>LTSS</literal> repositories contain new
+       packages for &reponame; &productnumber;.
+     </para>
+   </tip>
+  </step>
+  <step performance="optional">
+    <para>
+      If you need any of the <literal>BASE</literal>, <literal>Source</literal> or
+    <literal>Debug</literal>repositories, enable them with the following command:
+    </para>
+<screen>&prompt.root;<command>yum-config-manager --enable <replaceable>REPO_ID</replaceable></command></screen>
   </step>
   <step>
    <para>


### PR DESCRIPTION
### PR creator: Description

I'm 98% sure that last time I tested registration, LTSS-Updates and BASE-Updates were both enabled by default. 
Now only LTSS-Updates is enabled by default.


### PR creator: Are there any relevant issues/feature requests?

Inspired by investigating Issue #31, but technically not a fix for that.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
