### PR TITLE
Add SUMA guide and clarify subscriptions (SLL9)

### DIFF
--- a/DC-suma-quickstart
+++ b/DC-suma-quickstart
@@ -1,8 +1,8 @@
 #
-# DC file for SUSE Liberty Linux with RMT
+# DC file for SUSE Liberty Linux with SUSE Manager
 #
-MAIN="art-quickstart.xml"
-ROOTID="art-quickstart"
+MAIN="art-suma-quickstart.xml"
+ROOTID="art-suma-quickstart"
 
 PROFCONDITION="suse-product"
 #PROFCONDITION="suse-product;beta"

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -25,7 +25,8 @@
     This guide explains how to register and update &rhla;&nbsp;&productnumber; with &rmtool; (&rmt;).
    </para>
    <para>
-    To register with &suma;, see <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+    To register with &suma;, see
+    <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
     <citetitle>Registering &rhla; &productnumber; with &suma;</citetitle></link>.
    </para>
   </abstract>
@@ -39,7 +40,7 @@
    <dm:editurl>https://github.com/SUSE/doc-liberty/edit/main/xml/</dm:editurl>
    <dm:translation>no</dm:translation>
   </dm:docmanager>
-  <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with RMT</meta>
+  <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with &rmt;</meta>
   <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and RMT to update Red Hat Enterprise Linux 9.</meta>
   <meta name="social-descr" its:translate="yes">How to use RMT to update RHEL 9.</meta>
   <meta name="task" its:translate="yes">
@@ -98,7 +99,8 @@
     An optional &ha; extension is also available.
    </para>
    <para>
-    The following table shows which Linux distributions are supported by each subscription. These subscriptions also include an entitlement for a registration tool to manage package updates.
+    The following table shows which Linux distributions are supported by each subscription. These
+    subscriptions also include an entitlement for a registration tool to manage package updates.
    </para>
    <table xml:id="supported-distros-and-reg-tools">
      <title>Supported distributions and registration options</title>
@@ -111,8 +113,8 @@
            <entry>Subscription<footnote><para>The <emphasis>Lite</emphasis> and
            <emphasis>Basic</emphasis> subscriptions only support CentOS Linux,
            so are not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
-           <entry>Supported distributions<footnote><para>There is no CentOS Linux &productnumber;,
-           so CentOS Linux support is not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
+           <entry>Supported distributions<footnote><para>There is no CentOS Linux &productnumber;, so
+           CentOS Linux support is not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
            <entry>Registration options</entry>
          </row>
        </thead>
@@ -156,7 +158,8 @@
     the &rmt; server and receive packages from it directly.
    </para>
    <para>
-    To register with &suma;, see <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+    To register with &suma;, see
+    <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
     <citetitle>Registering &rhla; &productnumber; with &suma;</citetitle></link>.
    </para>
 

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -15,14 +15,18 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
 
  <info>
-  <title>Registering &rhla; &productnumber; with RMT</title>
+  <title>Registering &rhla; &productnumber; with &rmt;</title>
   <productname>&productname;</productname>
   <productname role="abbrev">&productnameshort;</productname>
   <date><?dbtimestamp format="B d, Y"?></date>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>
-    This guide describes how to use &productname; to update &rhel;&nbsp;&productnumber;.
+    This guide explains how to register and update &rhla;&nbsp;&productnumber; with &rmtool; (&rmt;).
+   </para>
+   <para>
+    To register with &suma;, see <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; with &suma;</citetitle></link>.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -36,13 +40,21 @@
    <dm:translation>no</dm:translation>
   </dm:docmanager>
   <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with RMT</meta>
-  <meta name="description" its:translate="yes">How to use SUSE Liberty Linux to update Red Hat Enterprise Linux 9.</meta>
-  <meta name="social-descr" its:translate="yes">How to use SUSE Liberty Linux to update RHEL 9.</meta>
+  <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and RMT to update Red Hat Enterprise Linux 9.</meta>
+  <meta name="social-descr" its:translate="yes">How to use RMT to update RHEL 9.</meta>
   <meta name="task" its:translate="yes">
     <phrase>Upgrade &amp; Update</phrase>
     <phrase>Administration</phrase>
   </meta>
   <revhistory xml:id="rh-art-quickstart">
+    <revision>
+      <date>2024-10-31</date>
+      <revdescription>
+        <para>
+          Clarify the tools available with each subscription level.
+        </para>
+      </revdescription>
+    </revision>
     <revision>
       <date>2024-10-22</date>
       <revdescription>
@@ -82,23 +94,72 @@
   <title>Introduction</title>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.
-    With a &productname; subscription, you can register and receive updates for
-    &rhel; and &sles;. An optional &ha; extension is also available.
+    With a &productname; subscription, you can register and update &rhel;.
+    An optional &ha; extension is also available.
    </para>
+   <para>
+    The following table shows which Linux distributions are supported by each subscription. These subscriptions also include an entitlement for a registration tool to manage package updates.
+   </para>
+   <table xml:id="supported-distros-and-reg-tools">
+     <title>Supported distributions and registration options</title>
+     <tgroup cols="3">
+     <colspec colname="c1" colwidth="31%"/>
+     <colspec colname="c2" colwidth="38%"/>
+     <colspec colname="c3" colwidth="31%"/>
+       <thead>
+         <row>
+           <entry>Subscription<footnote><para>The <emphasis>Lite</emphasis> and
+           <emphasis>Basic</emphasis> subscriptions only support CentOS Linux,
+           so are not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
+           <entry>Supported distributions<footnote><para>There is no CentOS Linux &productnumber;,
+           so CentOS Linux support is not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
+           <entry>Registration options</entry>
+         </row>
+       </thead>
+       <tbody>
+         <row>
+           <entry><para><emphasis>&productname; Enterprise</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+            <para>&sles;</para>
+           </entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Professional</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+           </entry>
+           <entry><para>&suma;</para></entry>
+         </row>
+       </tbody>
+     </tgroup>
+   </table>
    <important role="compact">
     <para>
      CentOS&nbsp;Stream is not supported.
     </para>
    </important>
+   <important role="compact">
+    <para>
+      Registering &rhla; directly with &scc; is not currently supported.
+    </para>
+   </important>
    <para>
-    You can register &rhla; &productnumber; with either &suma; or the &rmtool; (&rmt;).
-    Registering directly with the &scc; is not currently supported.
+    This guide describes how to register with &rmtool; (&rmt;). &rmt; is a proxy system for
+    &scc;. The &rmt; server is registered with &scc;, and other systems are registered with
+    the &rmt; server and receive packages from it directly.
    </para>
    <para>
-    This guide describes how to register with an &rmt; server. &rmt; is a proxy system for the
-    &scc;. The &rmt; server is registered with the &scc;, and other systems in the network are
-    registered with the &rmt; server and receive packages from it directly.
+    To register with &suma;, see <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; with &suma;</citetitle></link>.
    </para>
+
    <itemizedlist>
     <title>Procedure overview</title>
     <listitem>
@@ -132,21 +193,33 @@
     </listitem>
     <listitem>
      <para>
-      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
-      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with RMT</citetitle></link>
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/suma-quickstart/art-suma-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with &suma;</citetitle></link>
      </para>
     </listitem>
     <listitem>
      <para>
-      <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
-      <citetitle>Registering &rhla; 8 or CentOS Linux 8 with RMT</citetitle></link>
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with &rmt;</citetitle></link>
      </para>
     </listitem>
     <listitem>
       <para>
-        <link xlink:href="https://documentation.suse.com/suma/4.3/en/suse-manager/client-configuration/clients-sleses.html">
-        <citetitle>&suma; Client Configuration Guide: Registering &sliberty; Clients</citetitle></link>
+        <link xlink:href="https://documentation.suse.com/liberty/8/html/suma-quickstart/art-suma-quickstart.html">
+        <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &suma;</citetitle></link>
       </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &rmt;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+      <citetitle>Registering &rhla; 9 with &suma;</citetitle></link>
+     </para>
     </listitem>
    </itemizedlist>
  </section>
@@ -175,7 +248,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>&productname; doesn't appear in <command>rmt-cli products list</command>
+    <term>&productname; does not appear in <command>rmt-cli products list</command>
      after <command>rmt-cli sync</command></term>
     <listitem>
      <para>

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE article
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<article xml:id="art-suma-quickstart" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <info>
+  <title>Registering &rhla; &productnumber; with &suma;</title>
+  <productname>&productname;</productname>
+  <productname role="abbrev">&productnameshort;</productname>
+  <date><?dbtimestamp format="B d, Y"?></date>
+  <xi:include href="common_copyright_gfdl.xml"/>
+  <abstract>
+   <para>
+    This guide explains how to register and update &rhla;&nbsp;&productnumber; with &suma;.
+   </para>
+   <para>
+    To register with &rmt;, see <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; with &rmt;</citetitle></link>.
+   </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker>
+    <dm:url>https://github.com/SUSE/doc-liberty/issues/new</dm:url>
+    <dm:labels>documentation,issue</dm:labels>
+    <dm:version>8</dm:version>
+    <dm:assignee>tahliar</dm:assignee>
+   </dm:bugtracker>
+   <dm:editurl>https://github.com/SUSE/doc-liberty/edit/main/xml/</dm:editurl>
+   <dm:translation>no</dm:translation>
+  </dm:docmanager>  <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with &suma;</meta>
+  <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and SUSE Manager to update RHEL 9.</meta>
+  <meta name="social-descr" its:translate="yes">Use SUSE Manager to update RHEL 9.</meta>
+  <meta name="task" its:translate="yes">
+    <phrase>Upgrade &amp; Update</phrase>
+    <phrase>Administration</phrase>
+  </meta>
+  <revhistory xml:id="rh-art-suma-quickstart">
+    <revision>
+      <date>2024-10-31</date>
+      <revdescription>
+        <para>
+          Initial guide creation.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
+ </info>
+
+  <section xml:id="introduction-suma-quickstart">
+    <title>Introduction</title>
+    <para>
+    &productname; is a technology and support solution for mixed Linux environments.
+    With a &productname; subscription, you can register and update &rhel;.
+    An optional &ha; extension is also available.
+   </para>
+   <para>
+    The following table shows which Linux distributions are supported by each subscription. These subscriptions also include an entitlement for a registration tool to manage package updates.
+   </para>
+   <table xml:id="supported-distros-and-reg-tools">
+     <title>Supported distributions and registration options</title>
+     <tgroup cols="3">
+     <colspec colname="c1" colwidth="31%"/>
+     <colspec colname="c2" colwidth="38%"/>
+     <colspec colname="c3" colwidth="31%"/>
+       <thead>
+         <row>
+           <entry>Subscription<footnote><para>The <emphasis>Lite</emphasis> and
+           <emphasis>Basic</emphasis> subscriptions only support CentOS Linux,
+           so are not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
+           <entry>Supported distributions<footnote><para>There is no CentOS Linux &productnumber;,
+           so CentOS Linux support is not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
+           <entry>Registration options</entry>
+         </row>
+       </thead>
+       <tbody>
+         <row>
+           <entry><para><emphasis>&productname; Enterprise</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+            <para>&sles;</para>
+           </entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Professional</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+           </entry>
+           <entry><para>&suma;</para></entry>
+         </row>
+       </tbody>
+     </tgroup>
+   </table>
+   <important role="compact">
+    <para>
+     CentOS&nbsp;Stream is not supported.
+    </para>
+   </important>
+   <important role="compact">
+    <para>
+      Registering &rhla; directly with &scc; is not currently supported.
+    </para>
+   </important>
+   <para>
+    This guide describes how to register with &suma;. &suma; is a lifecycle management system for
+    mixed Linux environments. The &suma; Server is registered with &scc;, and other systems are
+    registered as clients of &suma; and receive packages from it directly.
+   </para>
+   <para>
+    To register with &rmtool;, see <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
+    <citetitle>Registering &rhla; 9 with &rmt;</citetitle></link>.
+   </para>
+
+   <itemizedlist>
+    <title>Procedure overview</title>
+    <listitem>
+     <para>
+      If &suma; is already set up and you only need to <emphasis role="bold">register your
+      &rhla;&nbsp;&productnumber; system</emphasis>, skip straight to
+      <xref linkend="register-rhel-with-suma"/>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      If you still need to <emphasis role="bold">set up &suma;</emphasis>, start with
+      <xref linkend="deploy-suma"/>.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <itemizedlist>
+    <title>Related information</title>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/suma/">&suma; documentation</link>
+      </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/suma-quickstart/art-suma-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with &suma;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with &rmt;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/liberty/8/html/suma-quickstart/art-suma-quickstart.html">
+        <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &suma;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &rmt;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 9 with &rmt;</citetitle></link>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </section>
+
+  <section xml:id="deploy-suma">
+    <title>Deploying &suma;</title>
+    <para>
+      See the following guide to install &suma; on &slem;, a lightweight, immutable operating system
+      for containerized and virtual workloads:
+      <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/quickstart/container-deployment/suma/quickstart-deploy-suma-server.html">
+      <citetitle>&suma; Quick Start</citetitle>: Deploy &suma; Server</link>.
+    </para>
+    <para>
+      You can use your &productname; subscription to register this machine.
+    </para>
+    <tip>
+      <title>Other installation options</title>
+      <para>
+        For additional installation options, see the full
+        <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/installation-and-upgrade/installation-and-upgrade-overview.html">
+        <citetitle>&suma; Installation and Upgrade Guide</citetitle></link>.
+      </para>
+      <para>
+        To deploy &suma; in the public cloud, see
+        <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/specialized-guides/public-cloud-guide/overview.html">
+        <citetitle>&suma; Public Cloud Guide</citetitle></link>.
+      </para>
+    </tip>
+    <important>
+      <title>&reponame; &productnumber; repository size</title>
+      <para>
+        The &reponame; &productnumber; repositories will grow over time because older package versions
+        are not removed. Based on the current<footnote><para>As of 22 October, 2024</para></footnote>
+        size of the repositories, to meet the 1.5 times size recommendation you will need
+        approximately 335&nbsp;GB of disk space for the default repositories.
+      </para>
+      <para>
+        If you need the optional <literal>Source</literal> and <literal>Debug</literal>
+        repositories, you will need an additional 665&nbsp;GB available.
+      </para>
+    </important>
+  </section>
+
+  <section xml:id="register-rhel-with-suma">
+    <title>Registering &rhla; with &suma;</title>
+    <para>
+      See the following guide to register &rhel; &productnumber; with &suma;:
+      <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/client-configuration/clients-sleses.html">
+      <citetitle>&suma; Client Configuration Guide</citetitle>: Registering &sliberty; Clients</link>.
+    </para>
+    <important role="compact">
+      <para>
+      CentOS Stream is not supported.
+      </para>
+    </important>
+  </section>
+
+ <xi:include href="common_legal.xml"/>
+</article>

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -65,7 +65,8 @@
     An optional &ha; extension is also available.
    </para>
    <para>
-    The following table shows which Linux distributions are supported by each subscription. These subscriptions also include an entitlement for a registration tool to manage package updates.
+    The following table shows which Linux distributions are supported by each subscription. These
+    subscriptions also include an entitlement for a registration tool to manage package updates.
    </para>
    <table xml:id="supported-distros-and-reg-tools">
      <title>Supported distributions and registration options</title>
@@ -78,8 +79,8 @@
            <entry>Subscription<footnote><para>The <emphasis>Lite</emphasis> and
            <emphasis>Basic</emphasis> subscriptions only support CentOS Linux,
            so are not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
-           <entry>Supported distributions<footnote><para>There is no CentOS Linux &productnumber;,
-           so CentOS Linux support is not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
+           <entry>Supported distributions<footnote><para>There is no CentOS Linux &productnumber;, so
+           CentOS Linux support is not applicable to &productname;&nbsp;&productnumber;.</para></footnote></entry>
            <entry>Registration options</entry>
          </row>
        </thead>
@@ -123,7 +124,8 @@
     registered as clients of &suma; and receive packages from it directly.
    </para>
    <para>
-    To register with &rmtool;, see <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
+    To register with &rmtool;, see
+    <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
     <citetitle>Registering &rhla; 9 with &rmt;</citetitle></link>.
    </para>
 
@@ -133,7 +135,7 @@
      <para>
       If &suma; is already set up and you only need to <emphasis role="bold">register your
       &rhla;&nbsp;&productnumber; system</emphasis>, skip straight to
-      <xref linkend="register-rhel-with-suma"/>.
+      <xref linkend="register-with-suma"/>.
      </para>
     </listitem>
     <listitem>
@@ -222,7 +224,7 @@
     </important>
   </section>
 
-  <section xml:id="register-rhel-with-suma">
+  <section xml:id="register-with-suma">
     <title>Registering &rhla; with &suma;</title>
     <para>
       See the following guide to register &rhel; &productnumber; with &suma;:

--- a/xml/configure-rmt-server.xml
+++ b/xml/configure-rmt-server.xml
@@ -70,7 +70,7 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
    </para>
    <tip role="compact">
     <para>
-     To find your organization credentials, log in to the
+     To find your organization credentials, log in to
      <link xlink:href="https://scc.suse.com">&scc;</link>, select your
      organization from <guimenu>My Organizations</guimenu>, and click
      <guimenu>Proxies</guimenu>. Your organization's <guimenu>Mirroring

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -21,7 +21,12 @@
   <para>
     Use this procedure to install a &minvm;, a preconfigured virtual machine image that contains a
     slimmed-down version of &sles; (&slsa;). This machine will be the &rmtool; (&rmt;) server.
-    You can use your &productname; subscription to register this machine.
+  </para>
+  <para>
+    You can use your &productname; <emphasis>Enterprise</emphasis> subscription to register
+    this machine. &productname; <emphasis>Professional</emphasis> does not include an entitlement
+    for &slsa;, so you will need a separate &slsa; subscription if you want to use &rmt;
+    instead of &suma;.
   </para>
   <tip>
     <title>Other installation options</title>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -42,7 +42,7 @@
   </listitem>
   <listitem>
    <para>
-    You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
+    You have a &productname; subscription activated in <link xlink:href="&sccurl;">&scc;</link>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -51,7 +51,7 @@
   </listitem>
   <listitem>
    <para>
-    You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
+    You have a &productname; subscription activated in <link xlink:href="&sccurl;">&scc;</link>.
    </para>
   </listitem>
   <listitem>


### PR DESCRIPTION
### PR creator: Description

SLL9 version of #36. This version required some changes to the table, as there is no CentOS Linux 9 so CentOS support is irrelevant. However, I didn't remove mention of it completely from the list of supported distributions, as the subscription itself still supports it, there just isn't a version 9 _to_ support. 

**PDFs:**

SUMA guide:
[art-suma-quickstart_en.pdf](https://github.com/user-attachments/files/17581489/art-suma-quickstart_en.pdf)

RMT guide new intro:
[art-quickstart_en.pdf](https://github.com/user-attachments/files/17581487/art-quickstart_en.pdf)


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #DOCTEAM-1621


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [x] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [ ] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
