### PR TITLE
Add SUMA guide and clarify subscriptions (SLL7)

### DIFF
--- a/DC-suma-quickstart
+++ b/DC-suma-quickstart
@@ -1,8 +1,8 @@
 #
-# DC file for SUSE Liberty Linux with RMT
+# DC file for SUSE Liberty Linux with SUMA
 #
-MAIN="art-quickstart.xml"
-ROOTID="art-quickstart"
+MAIN="art-suma-quickstart.xml"
+ROOTID="art-suma-quickstart"
 
 PROFAUDIENCE="sll"
 PROFCONDITION="suse-product"

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -22,8 +22,12 @@
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>
-    This guide describes how to use &productname; to update &rhel;&nbsp;&productnumber;
-    or CentOS&nbsp;Linux&nbsp;&productnumber;.
+    This guide explains how to register and update &rhla;&nbsp;&productnumber; or
+    CentOS&nbsp;Linux&nbsp;&productnumber; with &rmtool; (&rmt;).
+   </para>
+   <para>
+    To register with &suma;, see <link xlink:href="https://documentation.suse.com/liberty/7/html/suma-quickstart/art-suma-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; or CentOS Linux &productnumber; with &suma;</citetitle></link>.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -37,12 +41,20 @@
    <dm:translation>no</dm:translation>
   </dm:docmanager>
     <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and RMT to update Red Hat Enterprise Linux 7 or CentOS Linux 7.</meta>
-  <meta name="social-descr" its:translate="yes">Use SUSE Liberty Linux to update RHEL 7 or CentOS 7.</meta>
+  <meta name="social-descr" its:translate="yes">Use RMT to update RHEL 7 or CentOS 7.</meta>
   <meta name="task" its:translate="yes">
     <phrase>Upgrade &amp; Update</phrase>
     <phrase>Administration</phrase>
   </meta>
   <revhistory xml:id="rh-art-quickstart">
+    <revision>
+      <date>2024-10-31</date>
+      <revdescription>
+        <para>
+          Clarify the tools available with each subscription level.
+        </para>
+      </revdescription>
+    </revision>
     <revision>
       <date>2024-10-18</date>
       <revdescription>
@@ -126,8 +138,8 @@
      </para>
      <para>
        To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
-       systems, and to continue receiving new updates for existing systems, you must purchase a
-       <emphasis>&reponame; &productnumber;</emphasis> subscription.
+       systems, and to continue receiving new updates for existing systems, you must use an
+       <emphasis>LTSS</emphasis> subscription.
      </para>
      <para>
        Additionally, the optional &ha; extension is no longer supported with
@@ -142,23 +154,82 @@
    </important>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.
-    With a &productname; subscription, you can register and receive updates for
-    &rhel;, CentOS Linux, and &sles;.
+    With a &productname; subscription, you can register and update &rhel; and CentOS Linux.
    </para>
+   <para>
+    The following table shows which Linux distributions are supported by each subscription. These
+    subscriptions also include an entitlement for a registration tool to manage package updates.
+   </para>
+   <table xml:id="supported-distros-and-reg-tools">
+     <title>Supported distributions and registration options</title>
+     <tgroup cols="3">
+     <colspec colname="c1" colwidth="31%"/>
+     <colspec colname="c2" colwidth="38%"/>
+     <colspec colname="c3" colwidth="31%"/>
+       <thead>
+         <row>
+           <entry>Subscription</entry>
+           <entry>Supported distributions</entry>
+           <entry>Registration options</entry>
+         </row>
+       </thead>
+       <tbody>
+         <row>
+           <entry><para><emphasis>&productname; Enterprise</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+            <para>&sles;</para>
+           </entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Professional</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+           </entry>
+           <entry><para>&suma;</para></entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Basic</emphasis></para></entry>
+           <entry><para>CentOS Linux</para></entry>
+           <entry><para>&suma;</para></entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Lite</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>Includes <emphasis>one</emphasis> entitlement for &slsa; to host &rmt;</para>
+           </entry>
+           <entry><para>&rmtool;</para></entry>
+         </row>
+       </tbody>
+     </tgroup>
+   </table>
    <important role="compact">
     <para>
      CentOS&nbsp;Stream is not supported.
     </para>
    </important>
+   <important role="compact">
+    <para>
+      Registering &rhla; or CentOS Linux directly with &scc; is not currently supported.
+    </para>
+   </important>
    <para>
-    You can register &rhla; &productnumber; or CentOS Linux &productnumber; with either
-    &suma; or the &rmtool; (&rmt;). Registering directly with the &scc; is not currently supported.
+    This guide describes how to register with &rmtool; (&rmt;). &rmt; is a proxy system for
+    &scc;. The &rmt; server is registered with &scc;, and other systems are registered with
+    the &rmt; server and receive packages from it directly.
    </para>
    <para>
-    This guide describes how to register with an &rmt; server. &rmt; is a proxy system for the
-    &scc;. The &rmt; server is registered with the &scc;, and other systems in the network are
-    registered with the &rmt; server and receive packages from it directly.
+    To register with &suma;, see <link xlink:href="https://documentation.suse.com/liberty/7/html/suma-quickstart/art-suma-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; or CentOS Linux &productnumber; with &suma;</citetitle></link>.
    </para>
+
    <itemizedlist>
     <title>Procedure overview</title>
     <listitem>
@@ -203,22 +274,34 @@
      </para>
     </listitem>
     <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/liberty/7/html/suma-quickstart/art-suma-quickstart.html">
+        <citetitle>Registering &rhla; 7 or CentOS Linux 7 with &suma;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/liberty/8/html/suma-quickstart/art-suma-quickstart.html">
+        <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &suma;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
      <para>
       <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
       <citetitle>Registering &rhla; 8 or CentOS Linux 8 with RMT</citetitle></link>
      </para>
     </listitem>
     <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+        <citetitle>Registering &rhla; 9 with &suma;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
      <para>
       <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
       <citetitle>Registering &rhla; 9 with RMT</citetitle></link>
      </para>
-    </listitem>
-    <listitem>
-      <para>
-        <link xlink:href="https://documentation.suse.com/suma/4.3/en/suse-manager/client-configuration/clients-sleses.html">
-        <citetitle>&suma; Client Configuration Guide: Registering &sliberty; Clients</citetitle></link>
-      </para>
     </listitem>
    </itemizedlist>
  </section>
@@ -247,7 +330,7 @@
       </listitem>
     </varlistentry>
     <varlistentry>
-      <term>&productname; doesn't appear in <command>rmt-cli products list</command>
+      <term>&productname; does not appear in <command>rmt-cli products list</command>
       after <command>rmt-cli sync</command></term>
       <listitem>
       <para>

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE article
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<article xml:id="art-suma-quickstart" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:its="http://www.w3.org/2005/11/its"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <info>
+  <title>Registering &rhla; &productnumber; or CentOS Linux &productnumber; with &suma;</title>
+  <productname>&productname;</productname>
+  <productname role="abbrev">&productnameshort;</productname>
+  <date><?dbtimestamp format="B d, Y"?></date>
+  <xi:include href="common_copyright_gfdl.xml"/>
+  <abstract>
+   <para>
+    This guide explains how to register and update &rhla;&nbsp;&productnumber; or
+    CentOS&nbsp;Linux&nbsp;&productnumber; with &suma;.
+   </para>
+   <para>
+    To register with &rmt;, see <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; or CentOS Linux &productnumber; with &rmt;</citetitle></link>.
+   </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker>
+    <dm:url>https://github.com/SUSE/doc-liberty/issues/new</dm:url>
+    <dm:labels>documentation,issue</dm:labels>
+    <dm:version>8</dm:version>
+    <dm:assignee>tahliar</dm:assignee>
+   </dm:bugtracker>
+   <dm:editurl>https://github.com/SUSE/doc-liberty/edit/main/xml/</dm:editurl>
+   <dm:translation>no</dm:translation>
+  </dm:docmanager>  <meta name="title" its:translate="yes">Registering &rhla; &productnumber; or CentOS Linux &productnumber; with &suma;</meta>
+  <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and SUSE Manager to update RHEL 7 or CentOS Linux 7.</meta>
+  <meta name="social-descr" its:translate="yes">Use SUSE Manager to update RHEL 7 or CentOS 7.</meta>
+  <meta name="task" its:translate="yes">
+    <phrase>Upgrade &amp; Update</phrase>
+    <phrase>Administration</phrase>
+  </meta>
+  <revhistory xml:id="rh-art-suma-quickstart">
+    <revision>
+      <date>2024-10-31</date>
+      <revdescription>
+        <para>
+          Initial guide creation.
+        </para>
+      </revdescription>
+    </revision>
+  </revhistory>
+ </info>
+
+  <section xml:id="introduction-suma-quickstart">
+    <title>Introduction</title>
+    <important>
+     <title>End of general support for &productname; &productnumber;</title>
+     <para>
+       &productname; &productnumber; has reached the end of general support and is now in LTSS
+       (Long Term Service Support).
+     </para>
+     <para>
+       If you have a <emphasis>&productname;</emphasis> subscription but do not have an
+       <emphasis>LTSS</emphasis> subscription, you can continue to use your systems. However,
+       registering new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
+       systems with the general subscription is no longer supported.
+     </para>
+     <para>
+       To register new &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber;
+       systems, and to continue receiving new updates for existing systems, you must use an
+       <emphasis>LTSS</emphasis> subscription.
+     </para>
+     <para>
+       Additionally, the optional &ha; extension is no longer supported with
+       &reponame; &productnumber;. You must remove this product from your system
+       before you can register with an LTSS subscription.
+     </para>
+     <para>
+       If you previously registered your systems with a general subscription and want to move
+       them to an LTSS subscription, see <xref linkend="register-with-suma"/>.
+     </para>
+   </important>
+    <para>
+    &productname; is a technology and support solution for mixed Linux environments.
+    With a &productname; subscription, you can register and update &rhel; and CentOS Linux.
+   </para>
+   <para>
+    The following table shows which Linux distributions are supported by each subscription. These
+    subscriptions also include an entitlement for a registration tool to manage package updates.
+   </para>
+   <table xml:id="supported-distros-and-reg-tools">
+     <title>Supported distributions and registration options</title>
+     <tgroup cols="3">
+     <colspec colname="c1" colwidth="31%"/>
+     <colspec colname="c2" colwidth="38%"/>
+     <colspec colname="c3" colwidth="31%"/>
+       <thead>
+         <row>
+           <entry>Subscription</entry>
+           <entry>Supported distributions</entry>
+           <entry>Registration options</entry>
+         </row>
+       </thead>
+       <tbody>
+         <row>
+           <entry><para><emphasis>&productname; Enterprise</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+            <para>&sles;</para>
+           </entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Professional</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>&rhel;</para>
+           </entry>
+           <entry><para>&suma;</para></entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Basic</emphasis></para></entry>
+           <entry><para>CentOS Linux</para></entry>
+           <entry><para>&suma;</para></entry>
+         </row>
+         <row>
+           <entry><para><emphasis>&productname; Lite</emphasis></para></entry>
+           <entry>
+            <para>CentOS Linux</para>
+            <para>Includes <emphasis>one</emphasis> entitlement for &slsa; to host &rmt;</para>
+           </entry>
+           <entry><para>&rmtool;</para></entry>
+         </row>
+       </tbody>
+     </tgroup>
+   </table>
+   <important role="compact">
+    <para>
+     CentOS&nbsp;Stream is not supported.
+    </para>
+   </important>
+   <important role="compact">
+    <para>
+      Registering &rhla; or CentOS Linux directly with &scc; is not currently supported.
+    </para>
+   </important>
+   <para>
+    This guide describes how to register with &suma;. &suma; is a lifecycle management system for
+    mixed Linux environments. The &suma; Server is registered with &scc;, and other systems are
+    registered as clients of &suma; and receive packages from it directly.
+   </para>
+   <para>
+    To register with &rmtool;, see <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+    <citetitle>Registering &rhla; &productnumber; or CentOS Linux &productnumber; with &rmt;</citetitle></link>.
+   </para>
+
+   <itemizedlist>
+    <title>Procedure overview</title>
+    <listitem>
+     <para>
+      If &suma; is already set up and you only need to <emphasis role="bold">register your
+      &rhla;&nbsp;&productnumber; or CentOS&nbsp;Linux&nbsp;&productnumber; system</emphasis>,
+      skip straight to <xref linkend="register-with-suma"/>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      If you still need to <emphasis role="bold">set up &suma;</emphasis>, start with
+      <xref linkend="deploy-suma"/>.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <note><!-- Can delete this if/when all names have been changed
+              trichardson 2024-06-26: Repo names have changed but repo labels still include RES -->
+    <title><emphasis>&productname;</emphasis> and <emphasis>&sles; with Expanded Support</emphasis></title>
+    <para>
+     <emphasis>&productname;</emphasis> now provides what used to be covered by
+     the <emphasis>&sles; with Expanded Support</emphasis> subscription. Some
+     components might still use the <emphasis>Expanded Support</emphasis> name
+     during the transition period.
+    </para>
+   </note>
+   <itemizedlist>
+    <title>Related information</title>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/suma/">&suma; documentation</link>
+      </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/7/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 7 or CentOS Linux 7 with &rmt;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/liberty/8/html/suma-quickstart/art-suma-quickstart.html">
+        <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &suma;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/liberty/8/html/quickstart/art-quickstart.html">
+        <citetitle>Registering &rhla; 8 or CentOS Linux 8 with &rmt;</citetitle></link>
+      </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/9/html/suma-quickstart/art-suma-quickstart.html">
+      <citetitle>Registering &rhla; 9 with &suma;</citetitle></link>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <link xlink:href="https://documentation.suse.com/liberty/9/html/quickstart/art-quickstart.html">
+      <citetitle>Registering &rhla; 9 with &rmt;</citetitle></link>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </section>
+
+  <section xml:id="deploy-suma">
+    <title>Deploying &suma;</title>
+    <para>
+      See the following guide to install &suma; on &slem;, a lightweight, immutable
+      operating system for containerized and virtual workloads:
+      <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/quickstart/container-deployment/suma/quickstart-deploy-suma-server.html">
+      <citetitle>&suma; Quick Start</citetitle>: Deploy &suma; Server</link>.
+    </para>
+    <para>
+      You can use most &productname; subscriptions to register this machine. However,
+      the <emphasis>Lite</emphasis> subscription only includes an entitlement for &rmt;,
+      so if you want to use &suma; instead you will need a separate &suma; subscription.
+    </para>
+    <tip>
+      <title>Other installation options</title>
+      <para>
+        For additional installation options, see the full
+        <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/installation-and-upgrade/installation-and-upgrade-overview.html">
+        <citetitle>&suma; Installation and Upgrade Guide</citetitle></link>.
+      </para>
+      <para>
+        To deploy &suma; in the public cloud, see
+        <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/specialized-guides/public-cloud-guide/overview.html">
+        <citetitle>&suma; Public Cloud Guide</citetitle></link>.
+      </para>
+    </tip>
+    <important>
+      <title>&reponame; &productnumber; repository size</title>
+      <para>
+        The &reponame; &productnumber; repositories will grow over time because older package versions
+        are not removed. Based on the current<footnote><para>As of 31 October, 2024</para></footnote>
+        size of the repositories, to meet the 1.5 times size recommendation you will need
+        approximately 15&nbsp;GB of disk space for the default <literal>LTSS-Updates</literal>
+        repository. If you need the optional <literal>LTSS-Source</literal> and
+        <literal>LTSS-Debug</literal> repositories, you will need an additional 39&nbsp;GB.
+      </para>
+      <para>
+        &reponame; &productnumber; also has optional frozen <literal>BASE</literal> repositories
+        that contain the packages from the non-LTSS repositories. If you need these repositories,
+        to meet the 1.5 times size recommendation you will need approximately 210&nbsp;GB for the
+        <literal>BASE-Updates</literal> repository and 730&nbsp;GB for the
+        <literal>BASE-Source</literal> and <literal>BASE-Debug</literal> repositories.
+      </para>
+    </important>
+  </section>
+
+  <section xml:id="register-with-suma">
+    <title>Registering &rhla; or CentOS Linux with &suma;</title>
+    <important>
+      <title>New repositories for &reponame; &productnumber;</title>
+      <para>
+        The repository structure has changed in &reponame; &productnumber;.
+        If you previously registered your system with a general &productname; subscription,
+        follow the <citetitle>Client Configuration Guide</citetitle> again to add and
+        synchronize the LTSS repositories.
+      </para>
+      <para>
+        To clean up the old repositories, see
+        <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/administration/removing-channels.html">
+        <citetitle>&suma; Administration Guide</citetitle>: Remove Channels</link>.
+      </para>
+    </important>
+    <para>
+      See the following guide to register &rhel; &productnumber; or CentOS Linux &productnumber;
+      with &suma;:
+      <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/client-configuration/clients-sleses.html">
+      <citetitle>&suma; Client Configuration Guide</citetitle>: Registering &productname; Clients</link>.
+    </para>
+    <important role="compact">
+      <para>
+      CentOS Stream is not supported.
+      </para>
+    </important>
+  </section>
+
+ <xi:include href="common_legal.xml"/>
+</article>

--- a/xml/configure-rmt-server.xml
+++ b/xml/configure-rmt-server.xml
@@ -70,7 +70,7 @@ https://documentation.suse.com/sles/15-SP3/single-html/SLES-rmt/#sec-rmt-install
    </para>
    <tip role="compact">
     <para>
-     To find your organization credentials, log in to the
+     To find your organization credentials, log in to
      <link xlink:href="https://scc.suse.com">&scc;</link>, select your
      organization from <guimenu>My Organizations</guimenu>, and click
      <guimenu>Proxies</guimenu>. Your organization's <guimenu>Mirroring

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -19,8 +19,14 @@
  </info>
 
   <para>
-    Use this procedure to install a &minvm;, a preconfigured virtual machine image that contains a slimmed-down version of &sles; (&slsa;). This machine will be the &rmtool; (&rmt;) server.
-    You can use your &productname; subscription to register this machine.
+    Use this procedure to install a &minvm;, a preconfigured virtual machine image that contains a
+    slimmed-down version of &sles; (&slsa;). This machine will be the &rmtool; (&rmt;) server.
+  </para>
+  <para>
+    You can use your &productname; <emphasis>Lite</emphasis> or <emphasis>Enterprise</emphasis>
+    subscription to register this machine. <emphasis>Basic</emphasis> and
+    <emphasis>Professional</emphasis> do not include an entitlement for &slsa;, so you
+    will need a separate &slsa; subscription if you want to use &rmt; instead of &suma;.
   </para>
   <tip>
     <title>Other installation options</title>
@@ -71,19 +77,18 @@
       <important>
         <title>&reponame; &productnumber; repository size</title>
         <para>
-          The &reponame; &productnumber; repositories will grow over time because older package versions are not
-          removed. Based on the current<footnote><para>As of 17 September, 2024</para></footnote>
-          size of the repositories, to meet the 1.5 times size recommendation
-          you will need approximately 15&nbsp;GB of disk space for the default
-          <literal>LTSS-Updates</literal> repository.
-          If you need the optional <literal>LTSS-Source</literal> and <literal>LTSS-Debug</literal>
-         repositories, you will need an additional 39&nbsp;GB.
+          The &reponame; &productnumber; repositories will grow over time because older package versions
+          are not removed. Based on the current<footnote><para>As of 31 October, 2024</para></footnote>
+          size of the repositories, to meet the 1.5 times size recommendation you will need
+          approximately 15&nbsp;GB of disk space for the default <literal>LTSS-Updates</literal>
+          repository. If you need the optional <literal>LTSS-Source</literal> and
+          <literal>LTSS-Debug</literal> repositories, you will need an additional 39&nbsp;GB.
         </para>
         <para>
           &reponame; &productnumber; also has optional frozen <literal>BASE</literal> repositories
-          that contain the packages from the non-LTSS
-          repositories. If you need these repositories, to meet the 1.5 times size recommendation you will need approximately
-          210&nbsp;GB for the <literal>BASE-Updates</literal> repository and 730&nbsp;GB for the
+          that contain the packages from the non-LTSS repositories. If you need these repositories,
+          to meet the 1.5 times size recommendation you will need approximately 210&nbsp;GB for the
+          <literal>BASE-Updates</literal> repository and 730&nbsp;GB for the
           <literal>BASE-Source</literal> and <literal>BASE-Debug</literal> repositories.
         </para>
       </important>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -43,7 +43,7 @@
   </listitem>
   <listitem>
    <para>
-    You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
+    You have a &productname; subscription activated in <link xlink:href="&sccurl;">&scc;</link>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -53,7 +53,7 @@
   </listitem>
   <listitem>
    <para>
-    You have a &productname; subscription activated in the <link xlink:href="&sccurl;">&scc;</link>.
+    You have a &productname; subscription activated in <link xlink:href="&sccurl;">&scc;</link>.
    </para>
   </listitem>
   <listitem audience="sll">


### PR DESCRIPTION
### PR creator: Description

SLL7 version of #36. This version required some small changes related to LTSS: removing references to the HA extension and adding the Important admonitions.

**PDFs:**

SUMA guide:
[art-suma-quickstart_en.pdf](https://github.com/user-attachments/files/17582670/art-suma-quickstart_en.pdf)

RMT guide new intro:
[art-quickstart_en.pdf](https://github.com/user-attachments/files/17582664/art-quickstart_en.pdf)

### PR creator: Are there any relevant issues/feature requests?

* GitHub Issue #...
* Jira Issue #DOCTEAM-1621


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [ ] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
