### PR TITLE
RMT is now available with all subs (SLL8)

### DIFF
--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -48,6 +48,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2024-12-06</date>
+      <revdescription>
+        <para>
+          RMT is now available with all subscription levels.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-10-31</date>
       <revdescription>
         <para>
@@ -141,12 +149,18 @@
             <para>CentOS Linux</para>
             <para>&rhel;</para>
            </entry>
-           <entry><para>&suma;</para></entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
          </row>
          <row>
            <entry><para><emphasis>&productname; Basic</emphasis></para></entry>
            <entry><para>CentOS Linux</para></entry>
-           <entry><para>&suma;</para></entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
          </row>
          <row>
            <entry><para><emphasis>&productname; Lite</emphasis></para></entry>

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -48,6 +48,14 @@
   </meta>
   <revhistory xml:id="rh-art-suma-quickstart">
     <revision>
+      <date>2024-12-06</date>
+      <revdescription>
+        <para>
+          RMT is now available with all subscription levels.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-10-31</date>
       <revdescription>
         <para>
@@ -101,12 +109,18 @@
             <para>CentOS Linux</para>
             <para>&rhel;</para>
            </entry>
-           <entry><para>&suma;</para></entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
          </row>
          <row>
            <entry><para><emphasis>&productname; Basic</emphasis></para></entry>
            <entry><para>CentOS Linux</para></entry>
-           <entry><para>&suma;</para></entry>
+           <entry>
+            <para>&suma;</para>
+            <para>&rmtool;</para>
+           </entry>
          </row>
          <row>
            <entry><para><emphasis>&productname; Lite</emphasis></para></entry>

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -23,10 +23,7 @@
     slimmed-down version of &sles; (&slsa;). This machine will be the &rmtool; (&rmt;) server.
   </para>
   <para>
-    You can use your &productname; <emphasis>Lite</emphasis> or <emphasis>Enterprise</emphasis>
-    subscription to register this machine. <emphasis>Basic</emphasis> and
-    <emphasis>Professional</emphasis> do not include an entitlement for &slsa;, so you
-    will need a separate &slsa; subscription if you want to use &rmt; instead of &suma;.
+    You can use your &productname; subscription to register this machine.
   </para>
   <tip>
     <title>Other installation options</title>


### PR DESCRIPTION
### PR creator: Description

SLL8 version of #39. A SLES entitlement for RMT use is now available with all subscription levels.


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #DOCTEAM-1656


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SLL 9 *(current `main`, no backport necessary)*
- [x] SLL 8
- [ ] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
