### PR TITLE
Change name to Multi-Linux Support

### DIFF
--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -41,13 +41,21 @@
    <dm:translation>no</dm:translation>
   </dm:docmanager>
   <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with &rmt;</meta>
-  <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and RMT to update Red Hat Enterprise Linux 9.</meta>
+  <meta name="description" its:translate="yes">How to use &productname; and &rmt; to update &rhel; &productnumber;.</meta>
   <meta name="social-descr" its:translate="yes">How to use RMT to update RHEL 9.</meta>
   <meta name="task" its:translate="yes">
     <phrase>Upgrade &amp; Update</phrase>
     <phrase>Administration</phrase>
   </meta>
   <revhistory xml:id="rh-art-quickstart">
+    <revision>
+      <date>2024-12-10</date>
+      <revdescription>
+        <para>
+          Change to new product name where applicable (some items like repo names have not changed).
+        </para>
+      </revdescription>
+    </revision>
     <revision>
       <date>2024-12-06</date>
       <revdescription>
@@ -197,6 +205,16 @@
      </para>
     </listitem>
    </itemizedlist>
+
+   <note>
+     <title><emphasis>&productname;</emphasis> and <emphasis>SUSE Liberty Linux</emphasis></title>
+     <para>
+       <emphasis>&productname;</emphasis> was previously named <emphasis>SUSE Liberty Linux</emphasis>.
+       During the transition period, some components might still use the name
+       <emphasis>SUSE Liberty Linux</emphasis>.
+     </para>
+   </note>
+
    <itemizedlist>
     <title>Related information</title>
     <listitem>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -42,14 +42,14 @@
   </dm:docmanager>
   <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with &rmt;</meta>
   <meta name="description" its:translate="yes">How to use &productname; and &rmt; to update &rhel; &productnumber;.</meta>
-  <meta name="social-descr" its:translate="yes">How to use RMT to update RHEL 9.</meta>
+  <meta name="social-descr" its:translate="yes">How to use &rmt; to update &rhla; &productnumber;.</meta>
   <meta name="task" its:translate="yes">
     <phrase>Upgrade &amp; Update</phrase>
     <phrase>Administration</phrase>
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
-      <date>2024-12-10</date>
+      <date>2024-12-11</date>
       <revdescription>
         <para>
           Change to new product name where applicable (some items like repo names have not changed).

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -39,13 +39,21 @@
    <dm:editurl>https://github.com/SUSE/doc-liberty/edit/main/xml/</dm:editurl>
    <dm:translation>no</dm:translation>
   </dm:docmanager>  <meta name="title" its:translate="yes">Registering &rhla; &productnumber; with &suma;</meta>
-  <meta name="description" its:translate="yes">How to use SUSE Liberty Linux and SUSE Manager to update RHEL 9.</meta>
-  <meta name="social-descr" its:translate="yes">Use SUSE Manager to update RHEL 9.</meta>
+  <meta name="description" its:translate="yes">How to use &productname; and &suma; to update &rhel; &productnumber;.</meta>
+  <meta name="social-descr" its:translate="yes">Use &suma; to update &rhla; &productnumber;.</meta>
   <meta name="task" its:translate="yes">
     <phrase>Upgrade &amp; Update</phrase>
     <phrase>Administration</phrase>
   </meta>
   <revhistory xml:id="rh-art-suma-quickstart">
+    <revision>
+      <date>2024-12-11</date>
+      <revdescription>
+        <para>
+          Change to new product name where applicable (some items like repo names have not changed).
+        </para>
+      </revdescription>
+    </revision>
     <revision>
       <date>2024-12-06</date>
       <revdescription>
@@ -156,6 +164,16 @@
      </para>
     </listitem>
    </itemizedlist>
+
+   <note>
+     <title><emphasis>&productname;</emphasis> and <emphasis>SUSE Liberty Linux</emphasis></title>
+     <para>
+      <emphasis>&productname;</emphasis> was previously named <emphasis>SUSE Liberty Linux</emphasis>.
+      During the transition period, some components might still use the name
+      <emphasis>SUSE Liberty Linux</emphasis>.
+     </para>
+   </note>
+
    <itemizedlist>
     <title>Related information</title>
     <listitem>
@@ -221,9 +239,9 @@
       </para>
     </tip>
     <important>
-      <title>&reponame; &productnumber; repository size</title>
+      <title>&productname; &productnumber; repository size</title>
       <para>
-        The &reponame; &productnumber; repositories will grow over time because older package versions
+        The &productname; &productnumber; repositories will grow over time because older package versions
         are not removed. Based on the current<footnote><para>As of 22 October, 2024</para></footnote>
         size of the repositories, to meet the 1.5 times size recommendation you will need
         approximately 335&nbsp;GB of disk space for the default repositories.

--- a/xml/install-rmt-vm.xml
+++ b/xml/install-rmt-vm.xml
@@ -65,16 +65,16 @@
     </listitem>
     <listitem>
       <para>
-        The &rmt; server needs enough available disk space to mirror the &reponame; &productnumber;
+        The &rmt; server needs enough available disk space to mirror the &productname; &productnumber;
         repositories. Downloaded packages are stored in <filename>/var/lib/rmt/public/repo/</filename>.
         The amount of storage required depends on the number of repositories you mirror.
         We recommend at least 1.5 times the total size of all enabled repositories.
       </para>
       <important>
-        <title>&reponame; &productnumber; repository size</title>
+        <title>&productname; &productnumber; repository size</title>
         <para>
-          The &reponame; &productnumber; repositories will grow over time because older package versions
-          are not removed. Based on the current<footnote><para>As of 21 October, 2024</para></footnote>
+          The &productname; &productnumber; repositories will grow over time because older package
+          versions are not removed. Based on the current<footnote><para>As of 21 October, 2024</para></footnote>
           size of the repositories, to meet the 1.5 times size recommendation you will need
           approximately 335&nbsp;GB of disk space for the default repositories.
         </para>
@@ -156,7 +156,7 @@
       <para>
         If you did not already increase the VM's disk space before the installation began,
         increase it now. You might need to shut down the VM to do so. The VM must have enough
-        space to mirror the &reponame; &productnumber; repositories.
+        space to mirror the &productname; &productnumber; repositories.
       </para>
     </step>
   </procedure>

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -9,7 +9,7 @@
  xmlns="http://docbook.org/ns/docbook" version="5.1"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Mirroring &reponame; repositories with &rmt;</title>
+ <title>Mirroring &productname; repositories with &rmt;</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -18,7 +18,7 @@
  </info>
 
  <para>
-  Use this procedure to mirror the &reponame; repositories for &rhel; &productnumber;.
+  Use this procedure to mirror the &productname; repositories for &rhel; &productnumber;.
  </para>
  <itemizedlist>
   <title>Requirements</title>
@@ -31,7 +31,7 @@
    <para>
     The &rmt; server has enough storage available for repository mirroring. The amount of storage
     required depends on the number of repositories you mirror. We recommend at least 1.5 times
-    the total size of all enabled repositories. Be aware that the &reponame; repositories will
+    the total size of all enabled repositories. Be aware that the &productname; repositories will
     grow substantially over time.
    </para>
   </listitem>
@@ -48,7 +48,7 @@
  </itemizedlist>
 
  <procedure xml:id="pro-mirror-repositories-with-rmt">
-  <title>Mirroring the &reponame; repositories with &rmt;</title>
+  <title>Mirroring the &productname; repositories with &rmt;</title>
   <step>
    <para>
     On the &rmt; server, update the available product and repository metadata:
@@ -63,7 +63,7 @@
   </step>
   <step>
    <para>
-    Enable &reponame; &productnumber; using the product ID <literal>2538</literal>:
+    Enable &productname; &productnumber; using the product ID <literal>2538</literal>:
    </para>
 <screen>&prompt.root;<command>rmt-cli products enable 2538</command></screen>
    <para>
@@ -79,7 +79,7 @@
    <tip role="compact">
     <para>
      To check whether the &ha; extension is available, run this
-     command: <command>rmt-cli products list --all --name="Liberty" --version=&productnumber;</command>
+     command: <command>rmt-cli products list --all --name=&reponameshort;-HA</command>
     </para>
    </tip>
   </step>
@@ -91,21 +91,24 @@
    <itemizedlist>
      <listitem>
        <para>
-         <literal>SLL-9-Source-Updates</literal>, <literal>SLL-AS-9-Source-Updates</literal> and
-         <literal>SLL-CB-9-Source-Updates</literal>:
+         <literal>&reponameshort;-&productnumber;-Source-Updates</literal>,
+         <literal>&reponameshort;-AS-&productnumber;-Source-Updates</literal> and
+         <literal>&reponameshort;-CB-&productnumber;-Source-Updates</literal>:
        </para>
 <screen>&prompt.root;<command>rmt-cli repos enable 5964 5967 5970</command></screen>
      </listitem>
      <listitem>
        <para>
-         <literal>SLL-9-Debug-Updates</literal>, <literal>SLL-AS-9-Debug-Updates</literal> and
-         <literal>SLL-CB-9-Debug-Updates</literal>:
+         <literal>&reponameshort;-&productnumber;-Debug-Updates</literal>,
+         <literal>&reponameshort;-AS-&productnumber;-Debug-Updates</literal> and
+         <literal>&reponameshort;-CB-&productnumber;-Debug-Updates</literal>:
        </para>
 <screen>&prompt.root;<command>rmt-cli repos enable 5965 5968 5971</command></screen>
      </listitem>
      <listitem>
        <para>
-         <literal>SLL-9-HA-Source-Updates</literal> and <literal>SLL-9-HA-Debug-Updates</literal>:
+         <literal>&reponameshort;-&productnumber;-HA-Source-Updates</literal> and
+         <literal>&reponameshort;-&productnumber;-HA-Debug-Updates</literal>:
        </para>
 <screen>&prompt.root;<command>rmt-cli repos enable 5973 5974</command></screen>
      </listitem>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -1,9 +1,10 @@
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname            "SUSE Liberty Linux">
-<!ENTITY productnameshort       "SLL">
+<!ENTITY productname            "SUSE Multi-Linux Support">
+<!ENTITY productnameshort       "SMLS">
 <!ENTITY productnumber          "9">
 
 <!ENTITY reponame               "SUSE Liberty Linux">
+<!ENTITY reponameshort          "SLL">
 
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url               "https://github.com/SUSE/doc-liberty">

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -35,7 +35,7 @@
   </listitem>
   <listitem>
    <para>
-    The &reponame; &productnumber; repositories are available on the &rmt; server.
+    The &productname; &productnumber; repositories are available on the &rmt; server.
    </para>
   </listitem>
   <listitem>
@@ -127,8 +127,8 @@
 Installed Products:
 ------------------------------------------
 
-  &productname; release file
-  (SLL/&productnumber;/x86_64)
+  &reponame; release file
+  (&reponameshort;/&productnumber;/x86_64)
 
   Registered
 
@@ -140,7 +140,7 @@ Installed Products:
     If your subscription includes the &ha; extension, activate it with the
     following command:
    </para>
-<screen>&prompt.root;<command>&suseconnect; -p SLL-HA/&productnumber;/x86_64</command></screen>
+<screen>&prompt.root;<command>&suseconnect; -p &reponameshort;-HA/&productnumber;/x86_64</command></screen>
    <tip role="compact">
     <para>
      To check whether the extension is available, run the
@@ -154,11 +154,11 @@ Installed Products:
    </para>
 <screen>&prompt.root;<command>dnf repolist all</command></screen>
    <para>
-    The default repositories <literal>SLL-&productnumber;-Updates</literal>,
-    <literal>SLL-AS-&productnumber;-Updates</literal> and
-    <literal>SLL-CB-&productnumber;-Updates</literal> should be <literal>enabled</literal>.
-    If you activated the &ha; extension, <literal>SLL-9-HA-Updates</literal> should also be
-    <literal>enabled</literal>.
+    The default repositories <literal>&reponameshort;-&productnumber;-Updates</literal>,
+    <literal>&reponameshort;-AS-&productnumber;-Updates</literal> and
+    <literal>&reponameshort;-CB-&productnumber;-Updates</literal> should be <literal>enabled</literal>.
+    If you activated the &ha; extension, <literal>&reponameshort;-&productnumber;-HA-Updates</literal>
+    should also be <literal>enabled</literal>.
    </para>
    <para>
      You will also see optional <literal>Source</literal> and <literal>Debug</literal>


### PR DESCRIPTION
### PR creator: Description

As seen in https://www.suse.com/products/multi-linux-support/, Liberty's name has changed. I've updated where I was able, but some things like repo names and IDs have not changed yet (and might not until the next version). 

I'll update SUMA to Multi-Linux Manager separately. 

Backporting will not be completely simple; it will require additional changes for each version. 


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #DOCTEAM-1657


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [x] SLL 9 *(current `main`, no backport necessary)*
- [x] SLL 8
- [x] SLL 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
