### PR TITLE
Add HA back to 7 LTSS

### DIFF
--- a/xml/app-access-src-debug.xml
+++ b/xml/app-access-src-debug.xml
@@ -49,9 +49,10 @@
   </itemizedlist>
 
   <para>
-    Repositories must be mirrored on the &rmt; server before you can access them on your system.
-    <literal>BASE</literal>, <literal>Source</literal> and <literal>Debug</literal> repositories
-    are not mirrored by default. Use this procedure to mirror any additional repositories you need:
+    Repositories must be mirrored on the &rmt; server before you can access them on your &rhla;
+    or CentOS Linux system. &ha;, <literal>BASE</literal>, <literal>Source</literal> and
+    <literal>Debug</literal> repositories are not mirrored by default. Use this procedure to
+    mirror any additional repositories you need:
   </para>
   <procedure xml:id="pro-mirror-src-debug">
     <title>Mirroring additional repositories on the &rmt; server</title>
@@ -59,12 +60,29 @@
       <para>
         List the &productname; &productnumber; LTSS repositories:
       </para>
-<screen>&prompt.root;<command>rmt-cli repos list --all | grep -E "&reponameshort;-&productnumber;-(BASE|LTSS)"</command></screen>
-      <tip role="compact">
-        <para>
-          <literal>BASE</literal> repositories are frozen and contain the existing packages
-          from the non-LTSS &productname; &productnumber; repositories. <literal>LTSS</literal> repositories contain new packages for &productname; &productnumber; LTSS.
-        </para>
+<screen>&prompt.root;<command>rmt-cli repos list --all | grep -E "&reponameshort;-&productnumber;-(BASE|LTSS|LH)"</command></screen>
+      <tip>
+        <title>LTSS repository names</title>
+        <itemizedlist>
+          <listitem>
+            <para>
+              <literal>BASE</literal> repositories are frozen and contain the existing packages
+              from the non-LTSS repositories.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>LTSS</literal> repositories contain new packages for
+              &productname; &productnumber; LTSS.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>LH</literal> repositories are the &ha; repositories for
+              &productname; &productnumber; LTSS.
+            </para>
+          </listitem>
+        </itemizedlist>
       </tip>
       <para>
         If the repositories you need already have the status <literal>Mirror</literal>,
@@ -73,7 +91,7 @@
     </step>
     <step>
       <para>
-        Enable the repositories using their four-digit repository ID. You can enable multiple
+        Enable a repository using its four-digit repository ID. You can enable multiple
         repositories at once:
       </para>
 <screen>&prompt.root;<command>rmt-cli repos enable <replaceable>REPO_ID1</replaceable> <replaceable>REPO_ID2</replaceable> <replaceable>REPO_ID3</replaceable></command></screen>

--- a/xml/art-compliance-scans.xml
+++ b/xml/art-compliance-scans.xml
@@ -84,11 +84,6 @@
     systems, and to continue receiving new updates for existing systems, you must use an
     <emphasis>LTSS</emphasis> subscription.
   </para>
-  <para>
-    Additionally, the optional &ha; extension is no longer supported with
-    &productname; &productnumber; LTSS. You must remove this product from your system
-    before you can register with an LTSS subscription.
-  </para>
 </important>
 
   <section xml:id="sec-compliance-scans-introduction">

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -49,6 +49,14 @@
   </meta>
   <revhistory xml:id="rh-art-quickstart">
     <revision>
+      <date>2025-03-19</date>
+      <revdescription>
+        <para>
+          HA repositories are now available with LTSS
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-12-13</date>
       <revdescription>
         <para>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -432,7 +432,7 @@
       <listitem>
         <para>
           The repository shown in the error message might not be mirrored on the &rmt; server.
-          The optional <literal>BASE</literal>, <literal>Source</literal> and <literal>Debug</literal>
+          The optional &ha;, <literal>BASE</literal>, <literal>Source</literal> and <literal>Debug</literal>
           repositories can be enabled with <command>yum-config-manager</command> even if they are
           not available from &rmt;.
         </para>

--- a/xml/art-quickstart.xml
+++ b/xml/art-quickstart.xml
@@ -150,7 +150,7 @@
  <section xml:id="introduction-quickstart">
   <title>Introduction</title>
    <important>
-     <title>End of general support for &productname; &productnumber;</title>
+     <title>End of general support</title>
      <para>
        &productname; &productnumber; has reached the end of general support and is now in LTSS
        (Long Term Service Support).
@@ -167,19 +167,15 @@
        <emphasis>LTSS</emphasis> subscription.
      </para>
      <para>
-       Additionally, the optional &ha; extension is no longer supported with
-       &productname; &productnumber; LTSS. You must remove this product from your system
-       before you can register with an LTSS subscription.
-     </para>
-     <para>
-       If you previously registered your systems with a general subscription and want to move
-       them to an LTSS subscription, see <xref linkend="mirror-repositories-with-rmt"/>
+       If you previously registered with a general subscription and want to move
+       to an LTSS subscription, see <xref linkend="mirror-repositories-with-rmt"/>
        and <xref linkend="register-7-with-rmt"/>.
      </para>
    </important>
    <para>
     &productname; is a technology and support solution for mixed Linux environments.
     With a &productname; subscription, you can register and update &rhel; and CentOS Linux.
+    Optional &ha; repositories are also available.
    </para>
    <para>
     The following table shows which Linux distributions are supported by each subscription. These

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -48,6 +48,14 @@
   </meta>
   <revhistory xml:id="rh-art-suma-quickstart">
     <revision>
+      <date>2025-03-18</date>
+      <revdescription>
+        <para>
+          HA repositories are now available with LTSS
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2024-12-11</date>
       <revdescription>
         <para>
@@ -77,7 +85,7 @@
   <section xml:id="introduction-suma-quickstart">
     <title>Introduction</title>
     <important>
-     <title>End of general support for &productname; &productnumber;</title>
+     <title>End of general support</title>
      <para>
        &productname; &productnumber; has reached the end of general support and is now in LTSS
        (Long Term Service Support).
@@ -94,18 +102,14 @@
        <emphasis>LTSS</emphasis> subscription.
      </para>
      <para>
-       Additionally, the optional &ha; extension is no longer supported with
-       &productname; &productnumber; LTSS. You must remove this product from your system
-       before you can register with an LTSS subscription.
-     </para>
-     <para>
-       If you previously registered your systems with a general subscription and want to move
-       them to an LTSS subscription, see <xref linkend="register-with-suma"/>.
+       If you previously registered with a general subscription and want to move
+       to an LTSS subscription, see <xref linkend="register-with-suma"/>.
      </para>
    </important>
     <para>
     &productname; is a technology and support solution for mixed Linux environments.
     With a &productname; subscription, you can register and update &rhel; and CentOS Linux.
+    Optional &ha; repositories are also available.
    </para>
    <para>
     The following table shows which Linux distributions are supported by each subscription. These

--- a/xml/art-suma-quickstart.xml
+++ b/xml/art-suma-quickstart.xml
@@ -48,7 +48,7 @@
   </meta>
   <revhistory xml:id="rh-art-suma-quickstart">
     <revision>
-      <date>2025-03-18</date>
+      <date>2025-03-19</date>
       <revdescription>
         <para>
           HA repositories are now available with LTSS

--- a/xml/mirror-repositories-with-rmt.xml
+++ b/xml/mirror-repositories-with-rmt.xml
@@ -63,7 +63,8 @@
      &productname; &productnumber; LTSS.
    </para>
    <para>
-     There are no new &ha; repositories. &ha; is not supported with &productname; &productnumber; LTSS.
+     Additionally, the optional &ha; repositories are now included in the
+     &productname; &productnumber; LTSS product instead of a separate &ha; extension.
    </para>
    <para>
     If you previously mirrored the &productname; repositories with the general subscription,
@@ -82,7 +83,7 @@
        </para>
 <screen>&prompt.root;<command>rmt-cli products disable 1252</command></screen>
        <para>
-         &ha; is not supported with &productname; &productnumber; LTSS.
+         The &ha; repositories are now included in the &productname; &productnumber; LTSS product.
        </para>
      </listitem>
      <listitem>
@@ -119,38 +120,47 @@
   </step>
   <step>
    <para>
-    If you also need the <literal>BASE</literal>, <literal>Source</literal> or
+    If you also need the &ha;, <literal>BASE</literal>, <literal>Source</literal> or
     <literal>Debug</literal> repositories, enable them with the following commands:
    </para>
-   <itemizedlist>
-     <listitem>
+   <substeps>
+     <step>
        <para>
-         <literal>&reponameshort;-&productnumber;-BASE-Updates</literal>:
+        List the &productname; &productnumber; LTSS repositories:
        </para>
-<screen>&prompt.root;<command>rmt-cli repos enable 6986</command></screen>
-     </listitem>
-<listitem>
+<screen>&prompt.root;<command>rmt-cli repos list --all | grep -E "&reponameshort;-&productnumber;-(BASE|LTSS|LH)"</command></screen>
+     </step>
+     <step>
        <para>
-         <literal>&reponameshort;-&productnumber;-LTSS-Source-Updates</literal> and
-         <literal>&reponameshort;-&productnumber;-BASE-Source-Updates</literal>:
+        Enable a repository using its four-digit repository ID. You can enable multiple
+        repositories at once:
        </para>
-<screen>&prompt.root;<command>rmt-cli repos enable 6748 6987</command></screen>
-     </listitem>
-     <listitem>
-       <para>
-         <literal>&reponameshort;-&productnumber;-LTSS-Debug-Updates</literal> and
-         <literal>&reponameshort;-&productnumber;-BASE-Debug-Updates</literal>:
-       </para>
-<screen>&prompt.root;<command>rmt-cli repos enable 6985 6988</command></screen>
-     </listitem>
-   </itemizedlist>
-   <tip role="compact">
-     <para>
-       <literal>BASE</literal> repositories are frozen and contain the existing packages from the
-       non-LTSS &productname; repositories. <literal>LTSS</literal> repositories contain new
-       packages for &productname; &productnumber; LTSS.
-     </para>
-   </tip>
+<screen>&prompt.root;<command>rmt-cli repos enable <replaceable>REPO_ID1 REPO_ID2 REPO_ID3</replaceable></command></screen>
+     </step>
+   </substeps>
+   <tip>
+    <title>LTSS repository names</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <literal>BASE</literal> repositories are frozen and contain the existing packages
+          from the non-LTSS repositories.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>LTSS</literal> repositories contain new packages for
+          &productname; &productnumber; LTSS.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>LH</literal> repositories are the &ha; repositories for
+          &productname; &productnumber; LTSS.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </tip>
   </step>
   <step>
    <para>

--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -79,8 +79,8 @@
        </para>
 <screen>&prompt.root;<command>SUSEConnect --de-register</command></screen>
        <para>
-        This command also removes the &ha; extension if it was installed on your system.
-        &ha; is not supported with &productname; &productnumber; LTSS.
+        This command also removes the &ha; extension if it was installed on your system. The
+        &ha; repositories are now included in the &productname; &productnumber; LTSS product.
       </para>
      </listitem>
      <listitem>
@@ -181,33 +181,53 @@ Installed Products:
     <literal>enabled</literal>.
    </para>
    <para>
-     You will also see optional <literal>BASE</literal>, <literal>Source</literal> and
-     <literal>Debug</literal> repositories with the status <literal>disabled</literal>.
-     Be aware that these repositories are listed even if they are not mirrored on the &rmt; server.
-     You can check the mirrored repositories by browsing the directory listing at
-     <literal>https://<replaceable>RMT_SERVER</replaceable>/repo/SUSE/Updates/</literal> or by
-     logging in to the &rmt; server and running <command>rmt-cli repos list</command>.
+     You will also see optional repositories with the status <literal>disabled</literal>.
+     Be aware that these repositories are listed even if they are not mirrored on the &rmt;
+     server. You can check the mirrored repositories by browsing the directory listing at
+     <literal>https://<replaceable>RMT_SERVER</replaceable>/repo/SUSE/Updates/</literal>
+     or by logging in to the &rmt; server and running <command>rmt-cli repos list</command>.
    </para>
-   <tip role="compact">
-     <para>
-       <literal>BASE</literal> repositories are frozen and contain the existing packages from the
-       non-LTSS &productname; repositories. <literal>LTSS</literal> repositories contain new
-       packages for &productname; &productnumber; LTSS.
-     </para>
-   </tip>
+   <tip>
+    <title>LTSS repository names</title>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <literal>BASE</literal> repositories are frozen and contain the existing packages
+          from the non-LTSS repositories.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>LTSS</literal> repositories contain new packages for
+          &productname; &productnumber; LTSS.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>LH</literal> repositories are the &ha; repositories for
+          &productname; &productnumber; LTSS.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </tip>
   </step>
   <step>
     <para>
-      If you need any of the <literal>BASE</literal>, <literal>Source</literal> or
-    <literal>Debug</literal>repositories, enable them with the following command:
+      If you need any of the &ha;, <literal>BASE</literal>, <literal>Source</literal> or
+      <literal>Debug</literal>repositories, enable them using their <literal>repo id</literal>.
+      You can enable multiple repositories at once:
     </para>
-<screen>&prompt.root;<command>yum-config-manager --enable <replaceable>REPO_ID</replaceable></command></screen>
+<screen>&prompt.root;<command>yum-config-manager --enable <replaceable>REPO_ID1 REPO_ID2 REPO_ID3</replaceable></command></screen>
   </step>
   <step>
    <para>
     Run the update command to make sure there are no errors:
    </para>
 <screen>&prompt.root;<command>yum update</command></screen>
+    <para>
+      If you enabled a repository that is not mirrored on the &rmt; server,
+      you will see a <literal>404</literal> error.
+    </para>
   </step>
  </procedure>
  <para>


### PR DESCRIPTION
### PR creator: Description

The HA repos are now available with 7 LTSS. However, instead of a separate extension, they're just part of the regular LTSS subscription. This required some significant changes to the RMT guide, but only minor changes in other guides.

PDF for the RMT guide, which had the most changes: 
[art-quickstart_en.pdf](https://github.com/user-attachments/files/19310910/art-quickstart_en.pdf)

PDFs for the other guides, which only needed minimal changes:
[art-suma-quickstart_en.pdf](https://github.com/user-attachments/files/19310065/art-suma-quickstart_en.pdf)
[art-compliance-scans_en.pdf](https://github.com/user-attachments/files/19310066/art-compliance-scans_en.pdf)


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #SLL-536


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [ ] SUSE Multi-Linux Support 9 *(current `main`, no backport necessary)*
- [ ] SUSE Multi-Linux Support 8
- [x] SUSE Multi-Linux Support 7

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
