### PR TITLE
doc-kit run (fetch updates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ build/
 .idea/
 *.code-workspace
 .vimrc
+worktree
+.worktree
+worktrees
+.worktrees

--- a/doc-kit.conf
+++ b/doc-kit.conf
@@ -1,9 +1,9 @@
 type: docbook5-book
 variant: license-gfdl
 
-file: d5aba8356449342d0bac0a62116b85f1b44ee73d  .gitignore
+file: ff3dfe8d7e05c08517d1b055b278bbc9f7e0aa01  .gitignore
 file: c6b4745307e90c9b88905b434cbbaddc54e4541b  .editorconfig
-file: 9147816337d8bd34946d0c207cd0a33b037bead1  xml/generic-entities.ent
+file: 078c37d26e1a91c41b1689f88b4e006929c134c4  xml/generic-entities.ent
 file: a79a3bc929478668955564bab48aecc8502555f6  xml/network-entities.ent
 file: 42fafc60a5e9622a138cede94d63a5b0bdc118c1  xml/common_intro_available_doc.xml
 file: ee8dbf17324e3e72b54bcb6fcc5dec7f7e4e1e9b  xml/common_intro_support.xml

--- a/xml/generic-entities.ent
+++ b/xml/generic-entities.ent
@@ -57,13 +57,15 @@
 
 <!-- SUSE PRODUCTS -->
 
-<!ENTITY sliberty               "&suse; Liberty Linux">
+<!ENTITY sliberty               "&suse; Multi-Linux Support">
 <!ENTITY neuvector              "&ssecurity;">
 <!ENTITY sobservability         "&suse; Observability">
 <!ENTITY ssecurity              "&suse; Security">
+<!ENTITY sstorage               "&suse; Storage">
+<!ENTITY svirtualization        "&suse; Virtualization">
+<!ENTITY sappco                 "&suse; Application Collection">
 <!ENTITY ranchelemental         "&rancherprime;: OS Manager">
-<!ENTITY suseaifoundation       "&suse; AI Foundation">
-<!ENTITY suseailibrary          "&suse; AI Library">
+<!ENTITY ailibrary              "AI Library">
 <!ENTITY suseaisuite            "&suse; AI Suite">
 <!ENTITY suseai                 "&suse; AI">
 <!ENTITY rke2                   "&rancherprime;: RKE2">
@@ -87,7 +89,7 @@
 <!ENTITY sdk                    "&suse; Software Development Kit">
 <!ENTITY sles                   "&sle; Server">
 <!ENTITY sls                    "&sles;">
-<!ENTITY sles4sap               "&sls; for &sap; Applications">
+<!ENTITY sles4sap               "&sls; for &sap; applications">
 <!ENTITY s4s                    "&sles4sap;">
 <!ENTITY slem                   "&sle; Micro">
 <!ENTITY bci-product            "&slea; Base Container Images">
@@ -104,12 +106,11 @@
 <!ENTITY hageo                  "Geo Clustering for &sleha;">
 
 
-<!-- SUSE Manager -->
-<!ENTITY susemgr                "&suse; Manager">
-<!ENTITY suma                   "&susemgr;">
-<!ENTITY susemgrdb              "&suse; Manager with Database">
-<!ENTITY susemgrproxy           "&susemgr; Proxy">
-<!ENTITY smr                    "&susemgr; for Retail">
+<!-- SUSE Multi-Linux Manager -->
+
+<!ENTITY smlm             "&suse; Multi-Linux Manager">
+<!ENTITY smlm-proxy       "&smlm; Proxy">
+<!ENTITY smlm-retail      "&smlm; for Retail">
 
 
 <!-- SUSE PRODUCT ACRONYMS (as approved in TermWeb 2023) -->
@@ -133,8 +134,6 @@
 <!ENTITY capa                   "SUSE&nbsp;CAP">
 <!ENTITY caaspa                 "SUSE&nbsp;CaaSP">
 <!ENTITY caspa                  "&caaspa;">
-<!ENTITY sumaa                  "SUMA">
-<!ENTITY smra                   "SUMA&nbsp;for&nbsp;Retail">
 <!ENTITY suseaia                "&suse; AI">
 
 
@@ -145,7 +144,7 @@
 <!ENTITY slehpcreg              "&slereg; High Performance Computing">
 <!ENTITY slertreg               "&slereg; Real Time">
 <!ENTITY slsreg                 "&slereg; Server">
-<!ENTITY sles4sapreg            "&slsreg; for &sap; Applications">
+<!ENTITY sles4sapreg            "&slsreg; for &sap; applications">
 <!ENTITY slemreg                "&slereg; Micro">
 <!ENTITY susemgrreg             "&suse;&reg; Manager">
 
@@ -191,6 +190,7 @@ use &deng;! -->
 <!ENTITY ms                     "Microsoft">
 <!ENTITY msreg                  "<trademark xmlns='http://docbook.org/ns/docbook' class='registered'>&ms;</trademark>">
 <!ENTITY nvidia                 "NVIDIA">
+<!ENTITY nvidiareg              "&nvidia;*">
 <!ENTITY rh                     "Red Hat">
 <!ENTITY redhat                 "&rh;">
 <!ENTITY sap                    "SAP">
@@ -225,7 +225,20 @@ use &deng;! -->
 <!ENTITY etcd                   "etcd">
 <!ENTITY minio                  "MinIO">
 <!ENTITY okta                   "Okta">
+<!ENTITY certmanager            "cert-manager">
 
+
+<!-- NVIDIA products -->
+<!ENTITY cuda                   "CUDA">
+<!ENTITY cudareg                "&cuda;*">
+<!ENTITY jetson                 "Jetson">
+<!ENTITY jetsonreg              "&jetson;*">
+<!ENTITY jetpack                "JetPack">
+<!ENTITY jetpackreg             "&jetpack;*">
+<!ENTITY xavier                 "Xavier">
+<!ENTITY xavierreg              "&xavier;*">
+<!ENTITY orin                   "Orin">
+<!ENTITY orinreg                "&orin;*">
 
 <!-- SLE DVD IMAGE NAMES -->
 
@@ -629,6 +642,17 @@ use &deng;! -->
 <!ENTITY susefirewall           "SuSEfirewall2">
 <!ENTITY susefirewallfiles      "SuSEfirewall2">
 <!ENTITY mysql                  "&mariadb;">
+
+
+<!-- SUSE Manager -->
+<!ENTITY susemgr                "&suse; Manager">
+<!ENTITY suma                   "&susemgr;">
+<!ENTITY susemgrdb              "&suse; Manager with Database">
+<!ENTITY susemgrproxy           "&susemgr; Proxy">
+<!ENTITY smr                    "&susemgr; for Retail">
+<!ENTITY sumaa                  "SUMA">
+<!ENTITY smra                   "SUMA&nbsp;for&nbsp;Retail">
+
 
 <!--SUSE Manager, old guide names -->
 <!ENTITY mgrclientconfguide     "Client Configuration Guide">


### PR DESCRIPTION
@tahliar : This PR contains a doc-kit run to fetch the latest updates for the files that are managed by doc-kit. 

The `generic-entities.ent` provides you with the recent productname updates, the major ones being:

- 'SUSE Manager' to 'SUSE Multi-Linux Manager' (note: I did _not_ change the values of existing SuMa entities (as for our versioned docs we still need the old product name in our maintenance branches), but added new entities for SMLM. The first 'SuMa' version with the new name will be published at the same time like SLE 15 SP7, so in case you want to replace any `susemgr/suma/*` entities used within your XML files with the new `smlm*` entities for the next release of SUSE Multi-Linux Support, you can go ahead now in `main`. 

- SUSE Liberty Linux to SUSE Multi-Linux Support (in that case I have _changed_  the value of the existing entity `sliberty` but as you have used your own entity for your docs, this change probably does not affect your docs at all).
- 
- 'SUSE Linux Enterprise for SAP Applications' to 'SUSE Linux Enterprise for SAP applications' (this change needs to be reflected across all our docs, therefore we have changed the value of the respective entity).

Please check if the doc-kit updates does not break any of your SMLS docs. 

If you are fine with the changes, could I ask you to run a doc-kit update yourself for the other maintenance branches of this repo? 

Many thanks!  
