### PR TITLE
Change download command to use curl -O

### DIFF
--- a/xml/register-with-rmt.xml
+++ b/xml/register-with-rmt.xml
@@ -66,7 +66,7 @@
    <para>
     On the &rhla; system, download the <filename>rmt-client-setup-res</filename> script:
    </para>
-<screen>&prompt.root;<command>curl http://<replaceable>&rmt;_SERVER</replaceable>/tools/rmt-client-setup-res --output rmt-client-setup-res</command></screen>
+<screen>&prompt.root;<command>curl -O http://<replaceable>&rmt;_SERVER</replaceable>/tools/rmt-client-setup-res</command></screen>
   </step>
   <step>
    <para>


### PR DESCRIPTION
### PR creator: Description

Changed command to use `curl -O`. This helpfully shortens the command so it fits the page better.


### PR creator: Are there any relevant issues/feature requests?

* Jira Issue #DOCTEAM-1893


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- [x] SUSE Multi-Linux Support 9 *(current `main`, no backport necessary)*
- [x] SUSE Multi-Linux Support 8
- [ ] SUSE Multi-Linux Support 7 (already done)

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
